### PR TITLE
[BHP1-1096] Add Missing Fuel Moisture Conditionals

### DIFF
--- a/development/migrations/2025_02_24_add_mising_fuel_moisture_conditionals.clj
+++ b/development/migrations/2025_02_24_add_mising_fuel_moisture_conditionals.clj
@@ -1,0 +1,62 @@
+(ns migrations.2025-02-24-add-mising-fuel-moisture-conditionals
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def live-herbacheous
+  #{"111" "110" "155"})
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def all-codes-to-unhide
+  (set live-herbacheous))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def list-options
+  (:list/options (d/entity (d/db conn) (sm/name->eid conn :list/name "SurfaceFuelModels"))))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def individual-size-class-live-herbacheous-fuel-moisture-conditional (d/entity (d/db conn) 4611681620380881713))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defn add-values-to-conditional [conditional-entity values-to-add]
+  {:db/id              (:db/id conditional-entity)
+   :conditional/values (set (into (:conditional/values conditional-entity)
+                                  values-to-add))})
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload
+  [(add-values-to-conditional individual-size-class-live-herbacheous-fuel-moisture-conditional live-herbacheous)])
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (def tx-data (d/transact conn payload)))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/development/migrations/2025_02_24_add_mising_fuel_moisture_conditionals.clj
+++ b/development/migrations/2025_02_24_add_mising_fuel_moisture_conditionals.clj
@@ -21,20 +21,23 @@
 ;; Payload
 ;; ===========================================================================================================
 
+(def ten-h
+  #{"110"} )
+
 #_{:clj-kondo/ignore [:missing-docstring]}
 (def live-herbacheous
   #{"111" "110" "155"})
-
-#_{:clj-kondo/ignore [:missing-docstring]}
-(def all-codes-to-unhide
-  (set live-herbacheous))
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (def list-options
   (:list/options (d/entity (d/db conn) (sm/name->eid conn :list/name "SurfaceFuelModels"))))
 
 #_{:clj-kondo/ignore [:missing-docstring]}
+(def individual-size-class-ten-h-fuel-moisture-conditional (d/entity (d/db conn) 4611681620380881711))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
 (def individual-size-class-live-herbacheous-fuel-moisture-conditional (d/entity (d/db conn) 4611681620380881713))
+
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (defn add-values-to-conditional [conditional-entity values-to-add]
@@ -44,7 +47,8 @@
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (def payload
-  [(add-values-to-conditional individual-size-class-live-herbacheous-fuel-moisture-conditional live-herbacheous)])
+  [(add-values-to-conditional individual-size-class-ten-h-fuel-moisture-conditional ten-h)
+   (add-values-to-conditional individual-size-class-live-herbacheous-fuel-moisture-conditional live-herbacheous)])
 
 ;; ===========================================================================================================
 ;; Transact Payload


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1096

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open local VMS and run migration script in ns `migrations.2025-02-24-add-mising-fuel-moisture-conditionals`
2. Open local app and sync vms
3. Create Surface Worksheet
4. Select outputs: Flame Length
5. Navigate to Inputs > Fuel Model
7. Select "V-Ha/111"
8. Navigate to "Fuel Moisture". Select "Individual Size Class"
9. Ensure you see:
- 1-h Fuel Moisture
- 10-h Fuel Moisture
- Live Herbaceous
- Live Woody

10. Repeat steps 7 - 9 for "V-Hb/110" and "V-MH/115"

## Screenshots