### PR TITLE
[BHP1-1180] Fix Max Spot Distance from Torching Trees

### DIFF
--- a/behave-lib/include/cpp/sig-adapters/SIGSpot.cpp
+++ b/behave-lib/include/cpp/sig-adapters/SIGSpot.cpp
@@ -75,7 +75,7 @@ void SIGSpot::setFireType(FireType::FireTypeEnum fireType) {
 }
 
 double SIGSpot::getMaxMountainousTerrainSpottingDistanceFromTorchingTrees(LengthUnits::LengthUnitsEnum spottingDistanceUnits) const {
-    if (fireType_ == FireType::Surface or fireType_ == FireType::Crowning or fireType_ == FireType::ConditionalCrownFire) {
+    if (fireType_ == FireType::Crowning) {
         return -1;
     } else {
         return Spot::getMaxMountainousTerrainSpottingDistanceFromTorchingTrees(spottingDistanceUnits);


### PR DESCRIPTION
## Purpose

## Related Issues
Closes BHP1-1180

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open Local App and rerun worksheekt: 
[Spotting-Torching-Trees.zip](https://github.com/user-attachments/files/18950245/Spotting-Torching-Trees.zip)

2. Ensure the results for a "Surface" "Fire Type" has a value instead of a "-"