### PR TITLE
[BHP1-1211] Update Crown Size Submodule

### DIFF
--- a/development/migrations/2025_03_13_rearrange_group_variables_crown_size_submodule.clj
+++ b/development/migrations/2025_03_13_rearrange_group_variables_crown_size_submodule.clj
@@ -1,0 +1,108 @@
+(ns migrations.2025-03-13-rearrange-group-variables-crown-size-submodule
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; Rearrange group variables in crown size submodule like surface size submodule
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload
+  [(sm/postwalk-insert
+    {:db/id                        -1
+     :submodule/_groups            (sm/t-key->eid conn "behaveplus:crown:output:size")
+     :group/name                   "Crown - Fire Size"
+     :group/translation-key        "behaveplus:crown:output:size:crown-fire-size"
+     :group/result-translation-key "behaveplus:crown:result:size:crown-fire-size"})
+
+   ;; Move existing gruop variables to the new submodule "Crown Size" from above.
+   {:db/id                  (sm/t-key->eid conn "behaveplus:crown:output:size:fire_area:fire_area")
+    :group/_group-variables -1
+    :group-variable/order   0}
+
+   {:db/id                  (sm/t-key->eid conn "behaveplus:crown:output:size:fire_perimeter:fire_perimeter")
+    :group/_group-variables -1
+    :group-variable/order   1}
+
+   {:db/id                  (sm/t-key->eid conn "behaveplus:crown:output:size:length_to_width_ratio:length_to_width_ratio")
+    :group/_group-variables -1
+    :group-variable/order   2}
+
+   {:db/id                  (sm/t-key->eid conn "behaveplus:crown:output:size:spread_distance:spread_distance")
+    :group/_group-variables -1
+    :group-variable/order   3}
+
+   ;; remove reference to group-variables from current group so that when we delete the old groups, we do not also delete the group-variable. This is because group variables are set as compoenents to groups.
+   [:db/retract
+    (sm/t-key->eid conn "behaveplus:crown:output:size:fire_area")
+    :group/group-variables
+    (sm/t-key->eid conn "behaveplus:crown:output:size:fire_area:fire_area")]
+
+   [:db/retract
+    (sm/t-key->eid conn "behaveplus:crown:output:size:fire_perimeter")
+    :group/group-variables
+    (sm/t-key->eid conn "behaveplus:crown:output:size:fire_perimeter:fire_perimeter")]
+
+   [:db/retract
+    (sm/t-key->eid conn "behaveplus:crown:output:size:length_to_width_ratio")
+    :group/group-variables
+    (sm/t-key->eid conn "behaveplus:crown:output:size:length_to_width_ratio:length_to_width_ratio")]
+
+   [:db/retract
+    (sm/t-key->eid conn "behaveplus:crown:output:size:spread_distance")
+    :group/group-variables
+    (sm/t-key->eid conn "behaveplus:crown:output:size:spread_distance:spread_distance")]
+
+   ])
+
+(def translation-payload
+  (sm/build-translations-payload conn 100 {"behaveplus:crown:output:size:crown-fire-size" "Size"}))
+
+(def remove-groups-payload
+  [[:db/retractEntity
+    (sm/t-key->eid conn "behaveplus:crown:output:size:fire_area")]
+
+   [:db/retractEntity
+    (sm/t-key->eid conn "behaveplus:crown:output:size:fire_perimeter")]
+
+   [:db/retractEntity
+    (sm/t-key->eid conn "behaveplus:crown:output:size:length_to_width_ratio")]
+
+   [:db/retractEntity
+    (sm/t-key->eid conn "behaveplus:crown:output:size:spread_distance")]])
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (do (def tx-data (d/transact conn (concat payload translation-payload)))
+      (def tx-data-2 (d/transact conn remove-groups-payload)))
+  )
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (do
+    (sm/rollback-tx! conn @tx-data-2)
+    (sm/rollback-tx! conn @tx-data)))

--- a/development/migrations/2025_03_13_rearrange_group_variables_crown_size_submodule.clj
+++ b/development/migrations/2025_03_13_rearrange_group_variables_crown_size_submodule.clj
@@ -73,7 +73,7 @@
    ])
 
 (def translation-payload
-  (sm/build-translations-payload conn 100 {"behaveplus:crown:output:size:crown-fire-size" "Size"}))
+  (sm/build-translations-payload conn 100 {"behaveplus:crown:output:size:crown-fire-size" "Crown - Fire Size"}))
 
 (def remove-groups-payload
   [[:db/retractEntity

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -44,7 +44,7 @@
                                   ws-uuid
                                   (:db/id group)
                                   (:group/conditionals-operator group)]))
-            (let [variables (->> group (:group/group-variables) (sort-by :group-variable/variable-order))]
+            (let [variables (->> group (:group/group-variables) (sort-by :group-variable/order))]
               [:<>
                [component-fn ws-uuid group variables level]
                [:div.wizard-subgroup__indent


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1211

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open local VMS and run migration script in ns `migrations.2025-03-13-rearrange-group-variables-crown-size-submodule`
2. Open local App and open worksheet: 
[BHP1-1211-surface-crown.zip](https://github.com/user-attachments/files/19236940/BHP1-1211-surface-crown.zip)

3. Navigate to outputs > Size
4. Ensure the page now looks as such:
![image](https://github.com/user-attachments/assets/ef6ab67b-b769-4f51-8791-8e5905c0b646)


5. Rerun worksheet and ensure completion and there are values for the selected outputs

## Screenshots