### PR TITLE
[BHP1-1128] Fix Range Selector when using Negative Steps

### DIFF
--- a/projects/behave/src/cljs/behave/utils.cljs
+++ b/projects/behave/src/cljs/behave/utils.cljs
@@ -5,11 +5,16 @@
   ([] (range))
   ([end] (range (inc end)))
   ([start end] (range start (inc end)))
-  ([start end step] (when (pos? step)
+  ([start end step] (when (or (and (pos? step) (< start end))
+                              (and (neg? step) (> start end)))
                       (let [step-precision (max (count-precision start)
                                                 (count-precision end)
                                                 (count-precision step))
                             computed-range (range start (+ end step) step)]
                         (cond->> computed-range
-                          (< 0 step 1.0)                (map #(to-precision % step-precision))
-                          (> (last computed-range) end) butlast)))))
+                          (< -1.0 step 1.0)
+                          (map #(to-precision % step-precision))
+
+                          (or (and (pos? step) (> (last computed-range) end))
+                              (and (neg? step) (< (last computed-range) end)))
+                          butlast)))))


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1128

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open local app and create a Surface run
2. Navigate to Inputs > Wind and Slope
3. Select "Wind Measured At" = "20-ft"
4. Under "Wind Adjustment Factor - User Input" click "Range Selector"
5. Input test cases and ensure the values computed and the application does not hang:

Test case 1:
From: 0
To: 1
steps: 0.2

Test case 2:
From: 1
To: 0
steps: -0.2

## Screenshots