### PR TITLE
[BHP1-1127] Hide Discrete Output Graphs and settings

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/graphs.cljs
+++ b/projects/behave/src/cljs/behave/components/results/graphs.cljs
@@ -27,6 +27,7 @@
         [:div.wizard-results__graphs {:id "graph"}
          [:div.wizard-graph__header "Graphs"]
          (for [output-uuid @*output-uuids
+               :when       (not @(subscribe [:wizard/discrete-group-variable? output-uuid]))
                :let        [y-axis-limit (->> (:graph-settings/y-axis-limits graph-settings)
                                               (filter #(= output-uuid (:y-axis-limit/group-variable-uuid %)))
                                               (first))

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -529,7 +529,7 @@
                                                     @(<t (bp "maximum"))]
                                                    (mapv #(str/upper-case %)))
                                  :rf-event-id :worksheet/update-y-axis-limit-attr
-                                 :rf-sub-id   :worksheet/graph-settings-y-axis-limits
+                                 :rf-sub-id   :worksheet/graph-settings-y-axis-limits-filtered
                                  :min-attr-id :y-axis-limit/min
                                  :max-attr-id :y-axis-limit/max}])))])))
 

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -483,7 +483,7 @@
 
 (rf/reg-sub
  :worksheet/graph-settings-y-axis-limits-filtered
- (fn [[_ ws-uuid]] (rf/subscribe [:worksheet/table-settings-filters ws-uuid]))
+ (fn [[_ ws-uuid]] (rf/subscribe [:worksheet/graph-settings-y-axis-limits ws-uuid]))
  (fn [table-settings-filters _]
    (remove
     (fn [[group-var-uuid]]

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -481,6 +481,24 @@
              [?o :output/enabled? true]]
     :variables [ws-uuid]}))
 
+(rf/reg-sub
+ :worksheet/graph-settings-y-axis-limits-filtered
+ (fn [[_ ws-uuid]] (rf/subscribe [:worksheet/table-settings-filters ws-uuid]))
+ (fn [table-settings-filters _]
+   (remove
+    (fn [[group-var-uuid]]
+      (let [kind (d/q '[:find ?kind .
+                        :in  $ ?group-var-uuid
+                        :where
+                        [?gv :bp/uuid ?group-var-uuid]
+                        [?v :variable/group-variables ?gv]
+                        [?v :variable/kind ?kind]]
+                      @@vms-conn
+                      group-var-uuid)]
+        (or (= kind :discrete)
+            (= kind :text))))
+    table-settings-filters)))
+
 (rp/reg-sub
  :worksheet/graph-settings-x-axis-limits
  (fn [_ [_ ws-uuid]]


### PR DESCRIPTION
## Purpose

## Related Issues
Closes BHP1-1127

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open this worksheet: 
[BHP1-1127-PR.zip](https://github.com/user-attachments/files/19437574/BHP1-1127-PR.zip)

2. Navigate to "Results Settings" page
3. Ensure that "Fire Type" no longer shows in the Graph Settings
4. Navigate to "Results" page
5. Ensure "Fire Type" output graph no longer shows.


## Screenshots