### PR TITLE
[BHP1-1207] Fix Sidebar Module Order

### DIFF
--- a/projects/behave/src/cljs/behave/components/sidebar.cljs
+++ b/projects/behave/src/cljs/behave/components/sidebar.cljs
@@ -39,7 +39,7 @@
                             (map (fn [module-entity]
                                    (keyword (str/lower-case (:module/name module-entity))))
                                  @(rf/subscribe [:worksheet/modules ws-uuid])))
-        sidebar-modules   (or worksheet-modules
+        sidebar-modules   (or (seq worksheet-modules)
                               @(rf/subscribe [:state [:sidebar :*modules]]))
         on-select         #(do (rf/dispatch [:state/set [:sidebar :*modules] (:module %)])
                                (rf/dispatch [:state/set [:worksheet :*modules] (:module %)]))]

--- a/projects/behave/src/cljs/behave/components/sidebar.cljs
+++ b/projects/behave/src/cljs/behave/components/sidebar.cljs
@@ -3,6 +3,7 @@
    [behave.components.core :as c]
    [behave.components.a11y :refer [on-enter]]
    [behave.translate       :refer [<t bp]]
+   [clojure.string         :as str]
    [re-frame.core          :as rf]))
 
 (defn- sidebar-module [{icon-name       :icon
@@ -34,7 +35,10 @@
   [{:keys [ws-uuid]}]
   (let [*loaded?          (rf/subscribe [:app/loaded?])
         *hidden?          (rf/subscribe [:state [:sidebar :hidden?]])
-        worksheet-modules (when @*loaded? (:worksheet/modules @(rf/subscribe [:worksheet ws-uuid])))
+        worksheet-modules (when @*loaded?
+                            (map (fn [module-entity]
+                                   (keyword (str/lower-case (:module/name module-entity))))
+                                 @(rf/subscribe [:worksheet/modules ws-uuid])))
         sidebar-modules   (or worksheet-modules
                               @(rf/subscribe [:state [:sidebar :*modules]]))
         on-select         #(do (rf/dispatch [:state/set [:sidebar :*modules] (:module %)])


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1207

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open local App and create a Surface + Crown worksheet
2. Navigate to Outputs page.
3. Refresh the page and ensure the side bar modules order should be Surface then Crown

## Screenshots