### PR TITLE
HTML-Decode elmements after Hiccup conversion

### DIFF
--- a/projects/behave/src/cljs/behave/help/views.cljs
+++ b/projects/behave/src/cljs/behave/help/views.cljs
@@ -1,5 +1,6 @@
 (ns behave.help.views
   (:require [clojure.walk           :refer [postwalk]]
+            [clojure.string         :as str]
             [re-frame.core          :refer [subscribe dispatch dispatch-sync]]
             [reagent.core           :as r]
             [hickory.core           :as h]
@@ -7,6 +8,18 @@
             [behave.translate       :refer [<t]]
             [behave.help.events]
             [behave.help.subs]))
+
+;;; HTML Decoding
+
+(defonce ^:private html-codes
+  {"&amp;"   "&"
+   "&lt;"    "<"
+   "&gt;"    ">"
+   "&quot;"  "\""
+   "&apos;"  "'"})
+
+(defn- decode-html-string [html-str]
+  (str/replace html-str #"&\w+?;" html-codes))
 
 ;;; Helper Functions
 
@@ -114,7 +127,8 @@
        [:div.help-section__content
         (-> @help-contents
             (h/parse-fragment)
-            (->> (map h/as-hiccup)))])]))
+            (->> (map h/as-hiccup)
+                 (postwalk #(if (string? %) (decode-html-string %) %))))])]))
 
 (defn- help-content [help-keys & [children]]
   (let [help-highlighted-key (subscribe [:help/current-highlighted-key])]


### PR DESCRIPTION
-------

## Purpose
Fix HTML encoded elements (e.g. `&lt;`, `&amp;`)

## Related Issues
Closes [BHP1-1224](https://sig-gis.atlassian.net/browse/BHP1-1224)

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open a Surface worksheet
2. Select Heading / Rate of Spread as outputs
3. Go to Inputs, enter a fuel model
4. Go to Fuel Moisture, scroll to find `"1 HR Fuel < 0.25"`
5. Verify that it no longer shows `&lt;`

## Screenshots

[BHP1-1224]: https://sig-gis.atlassian.net/browse/BHP1-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ