### PR TITLE
[BHP1-1225] Add Mismatched Version Warning on Import Page

### DIFF
--- a/development/migrations/2025_03_31_add_version_warning_translations.clj
+++ b/development/migrations/2025_03_31_add_version_warning_translations.clj
@@ -1,0 +1,44 @@
+(ns migrations.2025-03-31-add-version-warning-translations
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload
+  (sm/build-translations-payload
+   conn
+   {"behaveplus:the-applicaiton-version-is-%s-but-your-run-is-%s"           "The application version is \"%s\" but your run is \"%s\"."
+    "behaveplus:review-your-outputs-and-inputs-before-calculating-this-run" "Review your outputs and inputs before calculating this run."}))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (def tx-data (d/transact conn payload)))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/development/migrations/2025_03_31_add_version_warning_translations.clj
+++ b/development/migrations/2025_03_31_add_version_warning_translations.clj
@@ -25,7 +25,7 @@
 (def payload
   (sm/build-translations-payload
    conn
-   {"behaveplus:the-applicaiton-version-is-%s-but-your-run-is-%s"           "The application version is \"%s\" but your run is \"%s\"."
+   {"behaveplus:the-application-version-is-%s-but-your-run-is-%s"           "The application version is \"%s\" but your run is \"%s\"."
     "behaveplus:review-your-outputs-and-inputs-before-calculating-this-run" "Review your outputs and inputs before calculating this run."}))
 
 ;; ===========================================================================================================

--- a/projects/behave/resources/public/css/app-style.css
+++ b/projects/behave/resources/public/css/app-style.css
@@ -299,6 +299,10 @@ body {
   padding-right: 15px
 }
 
+.workflow-select__warning {
+  padding: 5px;
+}
+
 .accordion {
   position: relative;
 }

--- a/projects/behave/src/cljs/behave/store.cljs
+++ b/projects/behave/src/cljs/behave/store.cljs
@@ -121,7 +121,9 @@
     (let [datoms (mapv #(apply d/datom %) (c/unpack body))]
       (rf/dispatch-sync [:ds/initialize (->ds-schema all-schemas) datoms])
       (rf/dispatch-sync [:state/set :sync-loaded? true])
-      (rf/dispatch-sync [:wizard/navigate-to-latest-worksheet]))))
+      (rf/dispatch-sync [:state/set :ws-version
+                         @(rf/subscribe [:worksheet/version @(rf/subscribe [:worksheet/latest])])]))))
+
 
 (defn open-worksheet! [{:keys [file]}]
   (let [form-data (js/FormData.)]

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -33,14 +33,15 @@
 (defn re-entity-from-eid [eid]
   (re/entity eid))
 
-;; Retrieve all worksheet UUID's
-(rp/reg-sub
+(rf/reg-sub
  :worksheet/all
  (fn [_ _]
-   {:type  :query
-    :query '[:find  ?created ?uuid
-             :where [?ws :worksheet/uuid ?uuid]
-             [?ws :worksheet/created ?created]]}))
+   (d/q '[:find ?created ?uuid
+          :in $
+          :where
+          [?e :worksheet/uuid ?uuid]
+          [?e :worksheet/created ?created]]
+        @@s/conn)))
 
 ;; Retrieve latest worksheet UUID
 (rf/reg-sub

--- a/projects/behave/src/cljs/behave/worksheet/views.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/views.cljs
@@ -139,7 +139,7 @@
                                 nil))
         ws-version  (r/track #(or @(rf/subscribe [:state :ws-version])
                                nil))
-        app-version (r/track #(or @(rf/subscribe [:state :version])
+        app-version (r/track #(or @(rf/subscribe [:state :app-version])
                                   nil))]
     [:<>
      [:div.workflow-select

--- a/projects/behave/src/cljs/behave/worksheet/views.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/views.cljs
@@ -157,7 +157,7 @@
          [:div.workflow-select__warning
           (str
            (gstring/format
-            @(<t (bp "the-applicaiton-version-is-%s-but-your-run-is-%s"))
+            @(<t (bp "the-application-version-is-%s-but-your-run-is-%s"))
             @app-version @ws-version)
            " "
            @(<t (bp "review-your-outputs-and-inputs-before-calculating-this-run")))])


### PR DESCRIPTION
## Purpose

## Related Issues
Closes BHP1-1225

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Create file: `projects/behave/resources/version.edn` if it does not already exist.

``` clojure
{:version "v7.0.0-alpha-test"}
```

2. Ensure that upon selecting this worksheet for import (you do not need to click next) a warning pops up for mismatched version: [bad-version.zip](https://github.com/user-attachments/files/19556163/bad-version.zip)

3. Click "Browse" and change the worksheet to this one: [alpha-test.zip](https://github.com/user-attachments/files/19556164/alpha-test.zip)
4. Ensure the warning now disappears.

## Screenshots