### PR TITLE
[BHP1-1215] Remove Worksheet Name

### DIFF
--- a/projects/behave/src/cljs/behave/worksheet/views.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/views.cljs
@@ -115,11 +115,7 @@
                                           :icons     [{:icon-name "contain"}]
                                           :selected? (= @*modules [:contain])
                                           :module    [:contain]}
-                                       ]}]
-       [:div.workflow-select__content__name
-
-        [c/text-input {:label     "Worksheet Name"
-                       :on-change #(rf/dispatch [:state/set [:worksheet :name] (input-value %)])}]]]
+                                       ]}]]
       [wizard-navigation {:next-label     @(<t (bp "next"))
                           :back-label     @(<t (bp "back"))
                           :next-disabled? (empty? @*modules)


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1215

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open App
2. Select "Guided Workflow"
3. Navigate to "Worksheet Selection" Page
4. Ensure the input field for worksheet name no longer shows

## Screenshots