### PR TITLE
[BHP1-1213] Filter unit selections with :domain/filtered-units

### DIFF
--- a/bases/behave_schema/src/behave/schema/domain.cljc
+++ b/bases/behave_schema/src/behave/schema/domain.cljc
@@ -25,21 +25,21 @@
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :domain/native-unit-uuid
-    :db/doc         "Doman's default native-unit uuid"
+    :db/doc         "Domain's default native-unit uuid"
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :domain/english-unit-uuid
-    :db/doc         "Doman's default english-unit uuid"
+    :db/doc         "Domain's default english-unit uuid"
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :domain/metric-unit-uuid
-    :db/doc         "Doman's default matric-unit uuid"
+    :db/doc         "Domain's default metric-unit uuid"
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :domain/dimension-uuid
-    :db/doc         "Doman's dimension uuid"
+    :db/doc         "Domain's dimension uuid"
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}])

--- a/bases/behave_schema/src/behave/schema/domain.cljc
+++ b/bases/behave_schema/src/behave/schema/domain.cljc
@@ -1,8 +1,32 @@
-(ns behave.schema.domain)
+(ns behave.schema.domain
+  (:require [clojure.spec.alpha :as s]
+            [behave.schema.utils :refer [uuid-string? zero-pos?]]))
+
+;; Domain Set
+(s/def :domain-set/name    string?)
+(s/def :domain-set/domains set?)
+
+(s/def :behave/domain-set (s/keys :req [:domain-set/name
+                                        :domain-set/domains]))
+
+(s/def :domain/name                string?)
+(s/def :domain/decimals            zero-pos?)
+(s/def :domain/dimension-uuid      uuid-string?)
+(s/def :domain/native-unit-uuid    uuid-string?)
+(s/def :domain/english-unit-uuid   uuid-string?)
+(s/def :domain/metric-unit-uuid    uuid-string?)
+(s/def :domain/filtered-unit-uuids (s/coll-of uuid-string?))
+
+(s/def :behave/domain (s/keys :req [:domain/name
+                                    :domain/dimension-uuid
+                                    :domain/native-unit-uuid
+                                    :domain/english-unit-uuid
+                                    :domain/metric-unit-uuid]
+                              :opt [:domain/filtered-unit-uuids
+                                    :domain/decimals]))
 
 (def schema
-  [
-   ;; Domain Set
+  [;; Domain Set
    {:db/ident       :domain-set/name
     :db/doc         "Domain set's name"
     :db/valueType   :db.type/string
@@ -42,4 +66,9 @@
    {:db/ident       :domain/dimension-uuid
     :db/doc         "Domain's dimension uuid"
     :db/valueType   :db.type/string
-    :db/cardinality :db.cardinality/one}])
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :domain/filtered-unit-uuids
+    :db/doc         "Domain's filtered unit UUID's."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/many}])

--- a/projects/behave/src/cljs/behave/components/unit_selector.cljs
+++ b/projects/behave/src/cljs/behave/components/unit_selector.cljs
@@ -38,8 +38,12 @@
 (defn unit-display
   "Displays the units for a continuous variable, and enables unit selection."
   [domain-uuid *unit-uuid dimension-uuid native-unit-uuid english-unit-uuid metric-unit-uuid & [on-change-units]]
-  (r/with-let [dimension         (rf/subscribe [:vms/entity-from-uuid dimension-uuid])
-               units             (:dimension/units @dimension)
+  (r/with-let [domain            (rf/subscribe [:vms/entity-from-uuid domain-uuid])
+               dimension         (rf/subscribe [:vms/entity-from-uuid dimension-uuid])
+               filtered-units    (set (:domain/filtered-unit-uuids @domain))
+               units             (cond->> (:dimension/units @dimension)
+                                   (seq filtered-units)
+                                   (filter #(filtered-units (:bp/uuid %))))
                units-by-uuid     (index-by :bp/uuid units)
                *cached-unit-uuid (rf/subscribe [:settings/cached-unit domain-uuid])
                *cached-unit      (rf/subscribe [:vms/entity-from-uuid @*cached-unit-uuid])

--- a/projects/behave_cms/src/cljs/behave_cms/client.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/client.cljs
@@ -3,6 +3,7 @@
             [reagent.core                       :as r]
             [reagent.dom                        :refer [render]]
             [re-frame.core                      :as rf]
+            [re-frisk.core                      :as re-frisk]
             [behave-cms.store                   :as s]
             [behave-cms.config                  :refer [update-config]]
             [behave-cms.events]
@@ -130,7 +131,8 @@
                      @original-params)]
     (update-config (:client-config clj-params))
     (render-root cur-params)
-    (rf/dispatch-sync [:initialize])))
+    (rf/dispatch-sync [:initialize])
+    (re-frisk/enable)))
 
 (defn- ^:after-load mount-root!
   "A hook for figwheel to call the init function again."

--- a/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
@@ -86,7 +86,8 @@
      :on-select #(on-change (long (u/input-value %)))
      :selected  (:db/id @state)}]])
 
-(defmethod field-input :checkbox [{:keys [label options on-change state]}]
+(defmethod field-input :checkbox [{:keys [label options on-change state disabled?]
+                                   :or   {disabled? false}}]
   (let [group-label label]
     [:div.mb-3
      [:label.form-label group-label]
@@ -98,8 +99,10 @@
                          @state)]
           ^{:key id}
           [:div.form-check
+           {:disabled disabled?}
            [:input.form-check-input
             {:type      "checkbox"
+             :disabled  disabled?
              :id        id
              :checked   checked?
              :on-change #(on-change (.. % -target -checked))}]

--- a/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
@@ -86,6 +86,31 @@
      :on-select #(on-change (long (u/input-value %)))
      :selected  (:db/id @state)}]])
 
+(defmethod field-input :set [{:keys [label options on-change state disabled?]
+                              :or   {disabled? false}}]
+  (let [state-as-set (set @state)
+        group-label  label]
+    [:div.mb-3
+     [:label.form-label group-label]
+     (doall
+      (for [{:keys [label value]} options]
+        (let [id       (u/sentence->kebab (str group-label ":" value))
+              checked? (state-as-set value)]
+          ^{:key id}
+          [:div.form-check
+           {:disabled disabled?}
+           [:input.form-check-input
+            {:type      "checkbox"
+             :disabled  disabled?
+             :id        id
+             :checked   checked?
+             :on-change #(let [enable? (.. % -target -checked)
+                               state'  (vec (if enable?
+                                              (conj state-as-set value)
+                                              (disj state-as-set value)))]
+                           (on-change state'))}]
+           [:label.form-check-label {:for id} label]])))]))
+
 (defmethod field-input :checkbox [{:keys [label options on-change state disabled?]
                                    :or   {disabled? false}}]
   (let [group-label label]

--- a/projects/behave_cms/src/cljs/behave_cms/domains/subs.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/subs.cljs
@@ -1,8 +1,6 @@
 (ns behave-cms.domains.subs
   (:require [re-frame.core :as rf]
-            [clojure.set :refer [rename-keys]]
-            [datascript.core :as d]
-            [behave-cms.store :refer [conn]]))
+            [clojure.set :refer [rename-keys]]))
 
 (rf/reg-sub
  :domains
@@ -20,79 +18,19 @@
 (rf/reg-sub
  :domains/dimension-units
  (fn [[_ dimension-eid]]
-   [(rf/subscribe [:pull '[*] dimension-eid])
-    (rf/subscribe [:domains/editor])])
- (fn [[domain domain-temp]]
-   (let [dimension-uuid (or (:domain/dimension-uuid domain-temp)
-                            (:domain/dimension-uuid domain))
+   [(rf/subscribe [:domains/editor])
+    (rf/subscribe [:pull '[*] dimension-eid])])
+ (fn [[domain domain-editor]]
+   (let [dimension-uuid (or domain-editor (:domain/dimension-uuid domain))
          dimension-eid  (rf/subscribe [:query '[:find ?e .
                                                 :where [?e :bp/uuid ?uuid]
                                                 :in $ ?uuid]
                                        [dimension-uuid]])]
      (-> (rf/subscribe [:pull '[*] @dimension-eid])
          (deref)
-         (:dimension/units)))))
-
-(rf/reg-sub
- :domains/dimension-units-2
- (fn [[_ dimension-eid]]
-   [(rf/subscribe [:pull '[*] dimension-eid])
-    (rf/subscribe [:domains/editor])])
- (fn [[domain domain-temp]]
-   (let [dimension-uuid (or (:domain/dimension-uuid domain-temp)
-                            (:domain/dimension-uuid domain))
-         dimension-eid  (rf/subscribe [:query '[:find ?e .
-                                                :where [?e :bp/uuid ?uuid]
-                                                :in $ ?uuid]
-                                       [dimension-uuid]])]
-     (-> (rf/subscribe [:pull '[*] @dimension-eid])
-         (deref)
-         (:dimension/units)))))
-
-
-(comment
-  (clear! :domains/dimension)
-  (rf/subscribe [:domains/editor])
-  (rf/subscribe [:domains/dimension-units 5330])
-
-
-  (defn clear! [k]
-    (rf/clear-sub k)
-    (rf/clear-subscription-cache!))
-
-  (clear! :domains/editor)
-
-  ;;; Write a Datomic Query with a pull in the :find statement
-  [:find (pull ?e [*])
-   :where
-   [?e :your-entity/attribute some-value]]
-
-  @(rf/subscribe [:query '[:find [(pull ?e [*])]
-                           :where [?e :bp/uuid ?uuid]
-                           :in $ ?uuid]
-                  [dimension-uuid]])
-
-  (def dimension-uuid @(rf/subscribe [:domains/dimension 5330]))
-  (rf/subscribe [:pull 
-                 '[*]
-                 ])
-
-  (rf/subscribe [:query '[:find ?e
-                          :where [?e :bp/uuid ?uuid]
-                          :in $ ?uuid]
-                 [dimension-uuid]])
-
-
-
-  (rf/subscribe [:pull '[*] 5330])
-
-
-  (rf/subscribe [:query '[:find ?a ?v
-                          :where [5330 ?a ?v]]])
-
-  []
-
-  )
+         (:dimension/units)
+         (->> (map #(rename-keys % {:unit/name :label
+                                    :bp/uuid   :value})))))))
 
 (rf/reg-sub
  :domain-sets

--- a/projects/behave_cms/src/cljs/behave_cms/domains/subs.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/subs.cljs
@@ -20,8 +20,9 @@
  (fn [[_ dimension-eid]]
    [(rf/subscribe [:domains/editor])
     (rf/subscribe [:pull '[*] dimension-eid])])
- (fn [[domain domain-editor]]
-   (let [dimension-uuid (or domain-editor (:domain/dimension-uuid domain))
+ (fn [[domain-editor domain]]
+   (let [dimension-uuid (or (:domain/dimension-uuid domain-editor)
+                            (:domain/dimension-uuid domain))
          dimension-eid  (rf/subscribe [:query '[:find ?e .
                                                 :where [?e :bp/uuid ?uuid]
                                                 :in $ ?uuid]

--- a/projects/behave_cms/src/cljs/behave_cms/domains/subs.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/subs.cljs
@@ -1,6 +1,8 @@
 (ns behave-cms.domains.subs
   (:require [re-frame.core :as rf]
-            [clojure.set :refer [rename-keys]]))
+            [clojure.set :refer [rename-keys]]
+            [datascript.core :as d]
+            [behave-cms.store :refer [conn]]))
 
 (rf/reg-sub
  :domains
@@ -8,6 +10,89 @@
    (rf/subscribe [:pull-with-attr :domain/name '[*]]))
  (fn [lists]
    (sort-by :domain/name lists)))
+
+(rf/reg-sub
+ :domains/editor
+ (fn [_]
+   (rf/subscribe [:state [:editors :domain]]))
+ identity)
+
+(rf/reg-sub
+ :domains/dimension-units
+ (fn [[_ dimension-eid]]
+   [(rf/subscribe [:pull '[*] dimension-eid])
+    (rf/subscribe [:domains/editor])])
+ (fn [[domain domain-temp]]
+   (let [dimension-uuid (or (:domain/dimension-uuid domain-temp)
+                            (:domain/dimension-uuid domain))
+         dimension-eid  (rf/subscribe [:query '[:find ?e .
+                                                :where [?e :bp/uuid ?uuid]
+                                                :in $ ?uuid]
+                                       [dimension-uuid]])]
+     (-> (rf/subscribe [:pull '[*] @dimension-eid])
+         (deref)
+         (:dimension/units)))))
+
+(rf/reg-sub
+ :domains/dimension-units-2
+ (fn [[_ dimension-eid]]
+   [(rf/subscribe [:pull '[*] dimension-eid])
+    (rf/subscribe [:domains/editor])])
+ (fn [[domain domain-temp]]
+   (let [dimension-uuid (or (:domain/dimension-uuid domain-temp)
+                            (:domain/dimension-uuid domain))
+         dimension-eid  (rf/subscribe [:query '[:find ?e .
+                                                :where [?e :bp/uuid ?uuid]
+                                                :in $ ?uuid]
+                                       [dimension-uuid]])]
+     (-> (rf/subscribe [:pull '[*] @dimension-eid])
+         (deref)
+         (:dimension/units)))))
+
+
+(comment
+  (clear! :domains/dimension)
+  (rf/subscribe [:domains/editor])
+  (rf/subscribe [:domains/dimension-units 5330])
+
+
+  (defn clear! [k]
+    (rf/clear-sub k)
+    (rf/clear-subscription-cache!))
+
+  (clear! :domains/editor)
+
+  ;;; Write a Datomic Query with a pull in the :find statement
+  [:find (pull ?e [*])
+   :where
+   [?e :your-entity/attribute some-value]]
+
+  @(rf/subscribe [:query '[:find [(pull ?e [*])]
+                           :where [?e :bp/uuid ?uuid]
+                           :in $ ?uuid]
+                  [dimension-uuid]])
+
+  (def dimension-uuid @(rf/subscribe [:domains/dimension 5330]))
+  (rf/subscribe [:pull 
+                 '[*]
+                 ])
+
+  (rf/subscribe [:query '[:find ?e
+                          :where [?e :bp/uuid ?uuid]
+                          :in $ ?uuid]
+                 [dimension-uuid]])
+
+
+
+  (rf/subscribe [:pull '[*] 5330])
+
+
+  (rf/subscribe [:query '[:find ?a ?v
+                          :where [5330 ?a ?v]]])
+
+  []
+
+  )
 
 (rf/reg-sub
  :domain-sets

--- a/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
@@ -8,7 +8,7 @@
 ;; Domain
 (defn- domain-editor [domain-set-eid domain-eid]
   (let [dimensions-options (rf/subscribe [:domains/options :dimension/name])
-        units-options      (rf/subscribe [:domains/dimension-units])]
+        units-options      (rf/subscribe [:domains/dimension-units domain-eid])]
     [:<>
      [:h3 (if domain-eid "Edit Domain" "Add Domain")]
      [entity-form {:entity       :domain
@@ -46,7 +46,7 @@
                                    :options   @units-options}
 
                                   {:label     "Filtered Units"
-                                   :type      :checkbox
+                                   :type      :set
                                    :required? true
                                    :field-key :domain/filtered-unit-uuids
                                    :options   @units-options}]

--- a/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
@@ -49,9 +49,8 @@
                                   {:label     "Filtered Units"
                                    :type      :checkbox
                                    :required? true
-                                   :field-key :domain/filtered-units
-                                   :options   @units-options}
-                                  ]
+                                   :field-key :domain/filtered-unit-uuids
+                                   :options   @units-options}]
                    :on-update #(cond-> %
                                  (:domain/decimals %)
                                  (update :domain/decimals long))}]]))

--- a/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
@@ -8,8 +8,7 @@
 ;; Domain
 (defn- domain-editor [domain-set-eid domain-eid]
   (let [dimensions-options (rf/subscribe [:domains/options :dimension/name])
-        dimension-uuid     (rf/subscribe [:state [:editors :domain :domain/dimension-uuid]])
-        units-options      (rf/subscribe [:domains/options :unit/name])]
+        units-options      (rf/subscribe [:domains/dimension-units])]
     [:<>
      [:h3 (if domain-eid "Edit Domain" "Add Domain")]
      [entity-form {:entity       :domain

--- a/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
@@ -8,6 +8,7 @@
 ;; Domain
 (defn- domain-editor [domain-set-eid domain-eid]
   (let [dimensions-options (rf/subscribe [:domains/options :dimension/name])
+        dimension-uuid     (rf/subscribe [:state [:editors :domain :domain/dimension-uuid]])
         units-options      (rf/subscribe [:domains/options :unit/name])]
     [:<>
      [:h3 (if domain-eid "Edit Domain" "Add Domain")]
@@ -43,7 +44,14 @@
                                    :type      :select
                                    :required? true
                                    :field-key :domain/metric-unit-uuid
-                                   :options   @units-options}]
+                                   :options   @units-options}
+
+                                  {:label     "Filtered Units"
+                                   :type      :checkbox
+                                   :required? true
+                                   :field-key :domain/filtered-units
+                                   :options   @units-options}
+                                  ]
                    :on-update #(cond-> %
                                  (:domain/decimals %)
                                  (update :domain/decimals long))}]]))


### PR DESCRIPTION
## Purpose
- Allows users to filter the units for a particular domain to display
  only a subset of units.

## Related Issues
Closes BHP1-1213

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Pull down latest VMS data from Dev
2. Start VMS & App
3. Open VMS > Variable Domains > Terrain & Spotting >Slope & Elevation
4. Select under `Filtered Units`: Feet, Miles, Kilometers, Meters (see
   screenshot 1)
5. Sync App
6. Open "Slope Tool" > Slope from Map Measurements
7. Verify that only the selected units are available in the dropdown
   (see screenshot 2)

## Screenshots
![CleanShot 2025-04-03 at 12 10 41](https://github.com/user-attachments/assets/8804e9e7-7e3f-472f-b31c-2e3c55058048)

![CleanShot 2025-04-03 at 12 09 15](https://github.com/user-attachments/assets/57e1e86b-a0a7-45f6-8094-8f4369b5630c)
