### PR TITLE
[BHP1-1263] Fix Application not Starting without version.edn

### DIFF
--- a/projects/behave/src/clj/behave/views.clj
+++ b/projects/behave/src/clj/behave/views.clj
@@ -54,7 +54,9 @@
   "Specifies head tag elements."
   []
   [:head
-   [:title (format "%s (%s)"  (get-config :site :title) (:app-version (get-app-version)))]
+   [:title (if (:app-version (get-app-version))
+            (format "%s (%s)"  (get-config :site :title) (:app-version (get-app-version)))
+            (get-config :site :title))]
    [:meta {:name    "description"
            :content (get-config :site :description)}]
    [:meta {:name "robots" :content "index, follow"}]
@@ -138,7 +140,11 @@
 (defn reset-app-version!
   "Resets the App version based on the file hash."
   []
-  (reset! *app-version (:version (edn/read-string (slurp (io/resource "version.edn"))))))
+  (reset! *app-version (some->> "version.edn"
+                                io/resource
+                                slurp
+                                edn/read-string
+                                :version)))
 
 (defn render-tests-page
   "Renders the site for tests."

--- a/projects/behave/src/cljs/behave/print/views.cljs
+++ b/projects/behave/src/cljs/behave/print/views.cljs
@@ -34,7 +34,7 @@
      [:div.print__header
       [:img {:src "/images/logo.svg"}]
       [:div.print__header__info
-       [:div (str "Version: " ws-version)]
+       (when ws-version [:div (str "Version: " ws-version)])
        [:div (str "Created: " (epoch->date-string ws-date-created))]]]
      [:div.wizard-print__header "Inputs"]
      [inputs-table ws-uuid]

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -85,10 +85,11 @@
 (rp/reg-event-fx
  :worksheet/new
  (fn [_ [_ {:keys [uuid name modules version]}]]
-   (let [tx {:worksheet/uuid    (or uuid (str (d/squuid)))
-             :worksheet/modules modules
-             :worksheet/created (.now js/Date)
-             :worksheet/version version}]
+   (let [tx (cond-> {:worksheet/uuid    (or uuid (str (d/squuid)))
+                     :worksheet/modules modules
+                     :worksheet/created (.now js/Date)}
+              version
+              (assoc :worksheet/version version))]
      {:transact [(merge tx (when name {:worksheet/name name}))]})))
 
 (rp/reg-event-fx


### PR DESCRIPTION
-------

## Purpose

Application would not start if a version.edn did not exist.

## Related Issues
Closes BHP1-1263

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Ensure you do not have a `resources/version.edn` file.
2. Open Application
3. Ensure it opens correctly
4. Ensure the title in the tab shows "BehavePlus" and not "BehavePlus (null)"

## Screenshots