### PR TITLE
[BHP1-1238] Add Tag-Set/Tags structure to VMS to enable Multi-tags sorting

### DIFF
--- a/bases/behave_components/resources/public/css/styles.css
+++ b/bases/behave_components/resources/public/css/styles.css
@@ -2284,6 +2284,12 @@ p {
   padding-right: 10px;
 }
 
+.multi-select__tags__tag > button {
+  font-size: var(--font-size-12);
+  font-weight: bold;
+}
+
+
 .multi-select__color-tags__tag,
 .multi-select__option__color-tag {
   border-left: 7px solid;

--- a/bases/behave_components/resources/public/css/styles.css
+++ b/bases/behave_components/resources/public/css/styles.css
@@ -2293,7 +2293,7 @@ p {
   font-size: var(--font-size-14);
 }
 
-.multi-slect__color-tags {
+.multi-select__color-tags {
   padding: 10px;
   margin: 0px 20px 15px 20px;
   display: flex;

--- a/bases/behave_components/resources/public/css/styles.css
+++ b/bases/behave_components/resources/public/css/styles.css
@@ -2286,7 +2286,7 @@ p {
 
 .multi-select__color-tags__tag,
 .multi-select__option__color-tag {
-  border-left: 7px solid var(--themed-multi-select-option-color);
+  border-left: 7px solid;
 }
 
 .multi-select__color-tags__tag {

--- a/bases/behave_components/src/cljs/behave/stories/multi_select_input_stories.cljs
+++ b/bases/behave_components/src/cljs/behave/stories/multi_select_input_stories.cljs
@@ -70,7 +70,8 @@
                                      :add-button-label  "Select More"
                                      :view-button-label "View"
                                      :input-label       "Input"
-                                     :tags-enabled?     true
+                                     :filter-tags       [{:id :odd :label "Odd" :order 2}
+                                                         {:id :even :label "Even" :order 1}]
                                      :options           [{:label       "option1"
                                                           :value       1
                                                           :tags        #{:odd}
@@ -117,58 +118,62 @@
 
 
 (defn ^:export Tags-and-color-tags []
-  (r/as-element [multi-select-input {:title               "Selected Inputs"
-                                     :prompt1             "View your Input selections"
-                                     :prompt2             "Your Input Selections"
-                                     :prompt3             "Please select from the following Inputs (you can select multiple)"
-                                     :add-button-label    "Select More"
-                                     :view-button-label   "View"
-                                     :input-label         "Input"
-                                     :tags-enabled?       true
-                                     :color-tags          {:example-color-tag1 "Text for Example Color 1"
-                                                           :example-color-tag2 "Text for Example Color 2"
-                                                           :example-color-tag3 "Text for Example Color 3"}
-                                     :options             [{:label       "option1"
-                                                            :value       1
-                                                            :tags        #{:odd}
-                                                            :color-tag   :example-color-tag1
-                                                            :on-deselect #(js/console.log "on-deselect:" %)
-                                                            :on-select   #(js/console.log "on-select:" %)
-                                                            :selected?   true}
+  (r/as-element [multi-select-input {:title             "Selected Inputs"
+                                     :prompt1           "View your Input selections"
+                                     :prompt2           "Your Input Selections"
+                                     :prompt3           "Please select from the following Inputs (you can select multiple)"
+                                     :add-button-label  "Select More"
+                                     :view-button-label "View"
+                                     :input-label       "Input"
+                                     :filter-tags       [{:id :odd :label "Odd" :order 1}
+                                                         {:id :even :label "Even" :order 2}]
+                                     :color-tags        [{:label "Example Color 1"
+                                                          :color "var(--green-2)"}
+                                                         {:label "Example Color 2"
+                                                          :color "var(--peach-2)"}
+                                                         {:label "Example Color 3"
+                                                          :color "var(--orange-2)"}]
+                                     :options           [{:label       "option1"
+                                                          :value       1
+                                                          :tags        #{:odd}
+                                                          :color-tag   {:color "var(--green-2)"}
+                                                          :on-deselect #(js/console.log "on-deselect:" %)
+                                                          :on-select   #(js/console.log "on-select:" %)
+                                                          :selected?   true}
 
-                                                           {:label       "option2"
-                                                            :tags        #{:even}
-                                                            :color-tag   :example-color-tag1
-                                                            :value       2
-                                                            :on-deselect #(js/console.log "on-deselect:" %)
-                                                            :on-select   #(js/console.log "on-select:" %)}
+                                                         {:label       "option-2"
+                                                          :tags        #{:even}
+                                                          :color-tag   {:color "var(--green-2)"}
+                                                          :value       2
+                                                          :on-deselect #(js/console.log "on-deselect:" %)
+                                                          :on-select   #(js/console.log "on-select:" %)}
 
-                                                           {:label       "option3"
-                                                            :value       3
-                                                            :tags        #{:odd}
-                                                            :color-tag   :example-color-tag2
-                                                            :on-deselect #(js/console.log "on-deselect:" %)
-                                                            :on-select   #(js/console.log "on-select:" %)
-                                                            :selected?   true}
+                                                         {:label       "option3"
+                                                          :value       3
+                                                          :tags        #{:odd}
+                                                          :color-tag   {:color "var(--peach-2)"}
+                                                          :on-deselect #(js/console.log "on-deselect:" %)
+                                                          :on-select   #(js/console.log "on-select:" %)
+                                                          :selected?   true}
 
-                                                           {:label       "option4"
-                                                            :value       4
-                                                            :tags        #{:even}
-                                                            :color-tag   :example-color-tag2
-                                                            :on-deselect #(js/console.log "on-deselect:" %)
-                                                            :on-select   #(js/console.log "on-select:" %)}
+                                                         {:label       "option4"
+                                                          :value       4
+                                                          :tags        #{:even}
+                                                          :color-tag   {:color "var(--peach-2)"}
+                                                          :on-deselect #(js/console.log "on-deselect:" %)
+                                                          :on-select   #(js/console.log "on-select:" %)}
 
-                                                           {:label       "option5"
-                                                            :value       5
-                                                            :tags        #{:odd}
-                                                            :color-tag   :example-color-tag3
-                                                            :on-deselect #(js/console.log "on-deselect:" %)
-                                                            :on-select   #(js/console.log "on-select:" %)
-                                                            :selected?   true}
+                                                         {:label       "option5"
+                                                          :value       5
+                                                          :tags        #{:odd}
+                                                          :color-tag   {:color "var(--orange-2)"}
+                                                          :on-deselect #(js/console.log "on-deselect:" %)
+                                                          :on-select   #(js/console.log "on-select:" %)
+                                                          :selected?   true}
 
-                                                           {:label       "option6"
-                                                            :value       6
-                                                            :tags        #{:even}
-                                                            :color-tag   :example-color-tag3
-                                                            :on-deselect #(js/console.log "on-deselect:" %)
-                                                            :on-select   #(js/console.log "on-select:" %)}]}]))
+                                                         {:label       "option6"
+                                                          :value       6
+                                                          :tags        #{:even}
+                                                          :color-tag   {:color "var(--orange-2)"}
+                                                          :on-deselect #(js/console.log "on-deselect:" %)
+                                                          :on-select   #(js/console.log "on-select:" %)}]}]))

--- a/bases/behave_schema/src/behave/schema/language.cljc
+++ b/bases/behave_schema/src/behave/schema/language.cljc
@@ -38,6 +38,7 @@
    {:db/ident       :language/shortcode
     :db/doc         "Language's short code (e.g. 'en-US')."
     :db/valueType   :db.type/string
+    :db/unique      :db.unique/identity
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :language/translation

--- a/bases/behave_schema/src/behave/schema/list.cljc
+++ b/bases/behave_schema/src/behave/schema/list.cljc
@@ -48,11 +48,22 @@
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 
+   ;;; Deprecated
    {:db/ident       :list/color-tags
     :db/doc         "Lists's color tags."
     :db/valueType   :db.type/ref
     :db/cardinality :db.cardinality/many
     :db/isComponent true}
+
+   {:db/ident       :list/tag-set
+    :db/doc         "Lists's tag set for filtering options."
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :list/color-tag-set
+    :db/doc         "Lists's color tag set."
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}
 
    {:db/ident       :list/options
     :db/doc         "List's options."
@@ -85,12 +96,24 @@
     :db/valueType   :db.type/long
     :db/cardinality :db.cardinality/one}
 
+   ;;; Deprecated
    {:db/ident       :list-option/tags
     :db/doc         "List option's filter tags."
     :db/valueType   :db.type/keyword
     :db/cardinality :db.cardinality/many}
 
+   {:db/ident       :list-option/tag-refs
+    :db/doc         "List option's filter tags."
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/many}
+
+   ;;; Deprecated
    {:db/ident       :list-option/color-tag
+    :db/doc         "List option's color tag."
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :list-option/color-tag-ref
     :db/doc         "List option's color tag."
     :db/valueType   :db.type/ref
     :db/cardinality :db.cardinality/one}
@@ -112,17 +135,66 @@
     :db/cardinality :db.cardinality/one}
 
    ;; List Color tags
+   ;;; Deprecated
    {:db/ident       :color-tag/id
     :db/doc         "Color tag's keyword id."
     :db/valueType   :db.type/keyword
     :db/cardinality :db.cardinality/one
     :db/unique      :db.unique/identity}
 
+   ;;; Deprecated
    {:db/ident       :color-tag/translation-key
     :db/doc         "Color tag's description translation key."
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one
-    :db/unique      :db.unique/identity}])
+    :db/unique      :db.unique/identity}
+
+   ;; Tag Sets
+   {:db/ident       :tag-set/name
+    :db/doc         "Tag set's name."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+
+   {:db/ident       :tag-set/color?
+    :db/doc         "Tag set color configuration."
+    :db/valueType   :db.type/boolean
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :tag-set/tags
+    :db/doc         "Tag set's tags."
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db/isComponent true}
+
+   {:db/ident       :tag-set/translation-key
+    :db/doc         "Tag's translation key."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+
+   ;; Tags
+   {:db/ident       :tag/name
+    :db/doc         "Tag set's name."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+
+   {:db/ident       :tag/translation-key
+    :db/doc         "Tag's translation key."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+
+   {:db/ident       :tag/order
+    :db/doc         "Tag's order."
+    :db/valueType   :db.type/long
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :tag/color
+    :db/doc         "Tag's color."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}])
 
 ;;; Tests
 

--- a/components/schema_migrate/src/schema_migrate/core.clj
+++ b/components/schema_migrate/src/schema_migrate/core.clj
@@ -287,6 +287,13 @@
 
     (map (fn [eid] [:db/retractEntity eid]) i18ns)))
 
+(defn ->entity
+  "Payload for an Entity"
+  [data]
+  (merge data
+         {:bp/uuid (rand-uuid)
+          :bp/nid  (nano-id)}))
+
 (defn ->gv-conditional
   "Payload for a Group Variable Conditional."
   [uuid operator value]

--- a/components/schema_migrate/src/schema_migrate/interface.clj
+++ b/components/schema_migrate/src/schema_migrate/interface.clj
@@ -86,6 +86,10 @@
        :doc      "Removes an entity's (and it's components) translation keys."}
   remove-nested-i18ns-tx c/remove-nested-i18ns-tx)
 
+(def ^{:arglists '([data])
+       :doc "Payload for a new Entity, which adds a :bp/nid and :bp/uuid."}
+  ->entity c/->entity)
+
 (def ^{:arglists '([uuid operator value])
        :doc "Payload for a Group Variable Conditional."}
   ->gv-conditional c/->gv-conditional)

--- a/development/migrations/2025_04_05_migrate_list_tags.clj
+++ b/development/migrations/2025_04_05_migrate_list_tags.clj
@@ -203,5 +203,5 @@
 ;; ===========================================================================================================
 
 (comment
-  (sm/rollback-tx! conn @tx-data-1)
-  (sm/rollback-tx! conn @tx-data-2))
+  (do (sm/rollback-tx! conn @tx-data-2)
+      (sm/rollback-tx! conn @tx-data-1)))

--- a/development/migrations/2025_04_05_migrate_list_tags.clj
+++ b/development/migrations/2025_04_05_migrate_list_tags.clj
@@ -108,7 +108,10 @@
 #_{:clj-kondo/ignore [:missing-docstring]}
 (def fuel-region-categories-tag-set (apply ->color-tag-set fuel-region-categories))
 #_{:clj-kondo/ignore [:missing-docstring]}
-(def fuel-region-categories-translations (apply ->tag-translations fuel-region-categories))
+(def fuel-region-categories-translations
+  {"behaveplus:tags:fuel-region-categories:standard"                         "Standard Fuel Models (Anderson, Scott and Burgan)"
+   "behaveplus:tags:fuel-region-categories:mediterranean"                    "Mediterranean Fuel Models (Fernandes et al; Portugal)"
+   "behaveplus:tags:fuel-region-categories:chapparal-and-coastal-sage-shrub" "Chaparral & Coastal Sage Shrub (Weise, Southern CA)"})
 
 ;;; Tag Sets
 #_{:clj-kondo/ignore [:missing-docstring]}

--- a/development/migrations/2025_04_05_migrate_list_tags.clj
+++ b/development/migrations/2025_04_05_migrate_list_tags.clj
@@ -1,0 +1,202 @@
+(ns migrations.2025-04-05-migrate-list-tags
+  (:require [schema-migrate.interface :as sm]
+            [string-utils.interface :refer [->str ->kebab]]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; Converts all existing :list/tags / :color-tags to :tag-sets
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def db (d/db conn))
+
+(defn- ->tag-set [tag-set-name tag-list]
+  (let [translation-key (str "behaveplus:tags:" (->kebab tag-set-name))]
+    (sm/->entity
+     {:tag-set/name            tag-set-name
+      :tag-set/translation-key translation-key
+      :tag-set/tags
+      (map (fn [[tag-name order]]
+             (let [tag-t-key (format "%s:%s" translation-key (->kebab tag-name))]
+               (sm/->entity
+                {:tag/name            tag-name
+                 :tag/order           order
+                 :tag/translation-key tag-t-key})))
+           tag-list)})))
+
+(defn- ->color-tag-set [tag-set-name tag-color-list]
+  (let [translation-key (str "behaveplus:tags:" (->kebab tag-set-name))]
+    (sm/->entity
+     {:tag-set/name            tag-set-name
+      :tag-set/color?          true
+      :tag-set/translation-key translation-key
+      :tag-set/tags
+      (map (fn [[tag-name order color]]
+             (let [tag-t-key (format "%s:%s" translation-key (->kebab tag-name))]
+               (sm/->entity
+                {:tag/name            tag-name
+                 :tag/order           order
+                 :tag/color           color
+                 :tag/translation-key tag-t-key})))
+           tag-color-list)})))
+
+(defn- ->tag-translations [tag-set-name tag-list]
+  (let [translation-key (str "behaveplus:tags:" (->kebab tag-set-name))
+        translations    {translation-key tag-set-name}]
+    (reduce
+     (fn [m [tag-name]]
+       (let [tag-t-key (format "%s:%s" translation-key (->kebab tag-name))]
+         (assoc m tag-t-key tag-name)))
+     translations
+     tag-list)))
+
+(defn- convert-existing-tags [conn list-name]
+  (->> (sm/name->nid conn :list/name list-name)
+       (conj [:bp/nid])
+       (d/pull (d/db conn) '[* {:list/options [*]}])
+       (:list/options)
+       (mapcat :list-option/tags)
+       (set)
+       (map ->str)
+       (sort)
+       (map-indexed #(conj [] %2 %1))))
+
+;;; Region Codes
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def region-codes
+  ["Region Codes"
+   (convert-existing-tags conn "MortalitySpeciesMasterList")])
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def region-codes-tag-set (apply ->tag-set region-codes))
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def region-codes-translations (apply ->tag-translations region-codes))
+
+;;; Fuel Types
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def fuel-types ["Fuel Types" [["Grass" 0]
+                               ["Grass Shrub" 1]
+                               ["Shrub" 2]
+                               ["Timber Understory" 3]
+                               ["Timber Litter" 4]
+                               ["Slash Blowdown" 5]]])
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def fuel-types-tag-set (apply ->tag-set fuel-types))
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def fuel-types-translations (apply ->tag-translations fuel-types))
+
+;;; Fuel Region Categories
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def fuel-region-categories
+  ["Fuel Region Categories" [["Standard"                         0 "#FFE93C"]
+                             ["Mediterranean"                    1 "#94A839"]
+                             ["Chapparal and Coastal Sage Shrub" 2 "#E06E59"]]])
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def fuel-region-categories-tag-set (apply ->color-tag-set fuel-region-categories))
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def fuel-region-categories-translations (apply ->tag-translations fuel-region-categories))
+
+;;; Tag Sets
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def tag-sets-payload
+  [region-codes-tag-set
+   fuel-types-tag-set
+   fuel-region-categories-tag-set])
+
+;;; Translations
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def translations-payload
+  (sm/build-translations-payload
+   conn
+   100
+   (merge
+    region-codes-translations
+    fuel-types-translations
+    fuel-region-categories-translations)))
+
+;;; Migrate Lists
+(defn- ->tag-map [tag-set & [tag-name-xform]]
+  (let [tag-name-xform (or tag-name-xform ->kebab)]
+    (->> tag-set
+         (:tag-set/tags)
+         (map (fn [t] [(-> t (:tag/name) tag-name-xform (keyword)) [:bp/nid (:bp/nid t)]]))
+         (into {}))))
+
+(def ^:private region-codes-map           (->tag-map region-codes-tag-set identity))
+(def ^:private fuel-types-map             (->tag-map fuel-types-tag-set   identity))
+(def ^:private fuel-region-categories-map (->tag-map fuel-region-categories-tag-set))
+
+(defn- pull-existing-list [list-name]
+  (d/entity db [:bp/nid (sm/name->nid conn :list/name list-name)]))
+
+(defn- add-tag-sets [db list-name filter-tag-set & [color-tag-set]]
+  (cond-> {:bp/nid        (sm/name->nid db :list/name list-name)
+           :list/tag-set [:bp/nid (:bp/nid filter-tag-set)]}
+    color-tag-set
+    (merge {:list/color-tag-set [:bp/nid (:bp/nid color-tag-set)]})))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defn migrate-existing-list-tags [list-name filter-tags-map & [color-tags-map]]
+  (let [existing-list    (pull-existing-list list-name)
+        existing-options (:list/options existing-list)]
+
+    (->> existing-options
+         (mapv
+          (fn [option]
+            (cond-> option
+              :always
+              (select-keys [:db/id :bp/nid])
+
+              (and filter-tags-map (:list-option/tags option))
+              (assoc :list-option/tag-refs (map filter-tags-map (:list-option/tags option)))
+
+              (and color-tags-map (:list-option/color-tag option))
+              (assoc :list-option/color-tag-ref (color-tags-map (-> option :list-option/color-tag :color-tag/id))))))
+         ;; Remove all 'nil' lists
+         (remove #(-> (:list-option/tag-refs %) (set) (= #{nil}))))))
+
+(def ^:private migrate-lists-payload 
+  (concat 
+   [(add-tag-sets conn "SurfaceFuelModels" fuel-types-tag-set fuel-region-categories-tag-set)
+    (add-tag-sets conn "WindDrivenSurfaceFuelModelCodes" fuel-types-tag-set fuel-region-categories-tag-set)
+    (add-tag-sets conn "MortalitySpeciesMasterList" region-codes-tag-set)]
+   (migrate-existing-list-tags "SurfaceFuelModels" fuel-types-map fuel-region-categories-map)
+   (migrate-existing-list-tags "WindDrivenSurfaceFuelModelCodes" fuel-types-map fuel-region-categories-map)
+   (migrate-existing-list-tags "MortalitySpeciesMasterList" region-codes-map)))
+
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload (concat tag-sets-payload translations-payload migrate-lists-payload))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (def tx-data (d/transact conn payload)))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/development/migrations/2025_04_05_migrate_list_tags.clj
+++ b/development/migrations/2025_04_05_migrate_list_tags.clj
@@ -187,7 +187,7 @@
 ;; ===========================================================================================================
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(def payload (concat tag-sets-payload translations-payload migrate-lists-payload))
+(def payload-new-tag-sets (concat tag-sets-payload translations-payload))
 
 ;; ===========================================================================================================
 ;; Transact Payload
@@ -195,11 +195,13 @@
 
 (comment
   #_{:clj-kondo/ignore [:missing-docstring]}
-  (def tx-data (d/transact conn payload)))
+  (def tx-data-1 (d/transact conn payload-new-tag-sets))
+  (def tx-data-2 (d/transact conn migrate-lists-payload)))
 
 ;; ===========================================================================================================
 ;; In case we need to rollback.
 ;; ===========================================================================================================
 
 (comment
-  (sm/rollback-tx! conn @tx-data))
+  (sm/rollback-tx! conn @tx-data-1)
+  (sm/rollback-tx! conn @tx-data-2))

--- a/projects/behave/src/cljs/behave/components/input_group.cljs
+++ b/projects/behave/src/cljs/behave/components/input_group.cljs
@@ -168,7 +168,6 @@
                options                   (sort-by :list-option/order
                                                   (filter #(not (:list-option/hide? %))
                                                           (:list/options llist)))
-               tags-enabled?             (seq? (mapcat :list-option/tags options))
                on-select                 #(rf/dispatch [:worksheet/upsert-multi-select-input
                                                         ws-uuid group-uuid repeat-id gv-uuid %])
                on-deselect               #(rf/dispatch [:worksheet/remove-multi-select-input
@@ -177,31 +176,35 @@
                                              (str/split ",")
                                              (set))
                ->option                  (fn [{value     :list-option/value
-                                               tags      :list-option/tags
-                                               color-tag :list-option/color-tag
+                                               tags      :list-option/tag-refs
+                                               color-tag :list-option/color-tag-ref
                                                t-key     :list-option/translation-key}]
-                                           {:value       value
-                                            :label       @(<t t-key)
-                                            :tags        (set tags)
-                                            :on-select   on-select
-                                            :on-deselect on-deselect
-                                            :selected?   (contains? ws-input-values value)
-                                            :color-tag (:color-tag/id
-                                                        @(rf/subscribe [:vms/entity-from-eid (:db/id color-tag)]))})]
+                                           (merge
+                                            {:value       value
+                                             :label       @(<t t-key)
+                                             :on-select   on-select
+                                             :on-deselect on-deselect
+                                             :selected?   (contains? ws-input-values value)}
+                                            (when tags {:tags (set (map :bp/nid tags))})
+                                            (when color-tag {:color (:tag/color color-tag)})))]
     :color-tag/id
     [:div.wizard-input
      {:on-click on-focus-click
       :on-focus on-focus-click}
      [c/multi-select-input
       (cond-> {:input-label   @(rf/subscribe [:wizard/gv-uuid->default-variable-name gv-uuid])
-               :tags-enabled? tags-enabled?
                :options       (doall (map ->option options))}
-        (:list/color-tags llist)
-        (assoc :color-tags (reduce (fn [acc {id              :color-tag/id
-                                             translation-key :color-tag/translation-key}]
-                                     (assoc acc id @(<t translation-key)))
-                                   {}
-                                   (:list/color-tags llist))))]]))
+        (:list/tag-set llist)
+        (assoc :filter-tags (map (fn [{id              :bp/nid
+                                       translation-key :tag/translation-key}]
+                                   {:id id :label @(<t translation-key)})
+                                 (-> llist (:list/tag-set llist) (:tag-set/tags))))
+
+        (:list/color-tag-set llist)
+        (assoc :color-tags (map (fn [{color           :tag/color
+                                      translation-key :tag/translation-key}]
+                                  {:color color :label @(<t translation-key)})
+                                (-> llist (:list/color-tag-set) (:tag-set/tags)))))]]))
 
 (defmethod wizard-input :text [{gv-uuid  :bp/uuid
                                 help-key :group-variable/help-key}

--- a/projects/behave/src/cljs/behave/components/input_group.cljs
+++ b/projects/behave/src/cljs/behave/components/input_group.cljs
@@ -186,7 +186,7 @@
                                              :on-deselect on-deselect
                                              :selected?   (contains? ws-input-values value)}
                                             (when tags {:tags (set (map :bp/nid tags))})
-                                            (when color-tag {:color (:tag/color color-tag)})))]
+                                            (when color-tag {:color-tag {:color (:tag/color color-tag)}})))]
     :color-tag/id
     [:div.wizard-input
      {:on-click on-focus-click

--- a/projects/behave/src/cljs/behave/wizard/subs.cljs
+++ b/projects/behave/src/cljs/behave/wizard/subs.cljs
@@ -162,7 +162,14 @@
    (subscribe [:vms/pull-children
                :submodule/groups
                submodule-id
-               '[* {:group/group-variables [* {:variable/_group-variables [* {:variable/list [* {:list/options [*]}]}]}]}
+               '[* {:group/group-variables
+                    [* {:variable/_group-variables
+                        [* {:variable/list
+                            [* {:list/tag-set [*]
+                                :list/color-tag-set [*]
+                                :list/options
+                                [* {:list-option/tag-refs      [*]
+                                    :list-option/color-tag-ref [*]}]}]}]}]}
                  {:group/children 6}]])) ;; recursively apply pattern up to 6 levels deep
 
  (fn [groups]

--- a/projects/behave_cms/src/cljc/behave_cms/routes.cljc
+++ b/projects/behave_cms/src/cljc/behave_cms/routes.cljc
@@ -31,6 +31,7 @@
                      :subgroups         :subgroup
                      :submodules        :submodule
                      :translations      :translation
+                     :tags              :tag
                      :tools             :tool
                      :subtools          :subtool
                      :subtool-variables :subtool-variable
@@ -104,6 +105,7 @@
       (entity-route :domains)
       (entity-route :lists)
       (entity-route :help-pages)
+      (entity-route :tags)
       (entity-route :tools)
       (entity-route :subtools)
       (entity-route :subtool-variables)

--- a/projects/behave_cms/src/cljs/behave_cms/client.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/client.cljs
@@ -22,6 +22,7 @@
             [behave-cms.languages.views         :refer [list-languages-page]]
             [behave-cms.lists.views             :refer [list-lists-page]]
             [behave-cms.modules.views           :refer [list-modules-page]]
+            [behave-cms.tags.views              :refer [tags-page]]
             [behave-cms.tools.views             :refer [tools-page]]
             [behave-cms.units.views             :refer [units-page]]
             [behave-cms.subtools.views          :refer [subtools-page]]
@@ -41,6 +42,7 @@
    {:page "Variables"            :path "/variables"}
    {:page "Variable  Domains"    :path "/domains"}
    {:page "Lists"                :path "/lists"}
+   {:page "Tags"                 :path "/tags"}
    {:page "Units"                :path "/units"}
    {:page "Languages"            :path "/languages"}
    {:page "Invite User"          :path "/invite-user"}])
@@ -59,6 +61,7 @@
                 :languages            list-languages-page
                 :lists                list-lists-page
                 :units                units-page
+                :tags                 tags-page
                 :variables            list-variables-page})
 
 (def system-pages {:login          login-page

--- a/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
@@ -126,7 +126,9 @@
 
 (defmethod field-input :set [{:keys [label options on-change state disabled?]
                               :or   {disabled? false}}]
-  (let [state-as-set (set @state)
+  (let [state-as-set (set (if (-> @state (first) (:db/id))
+                            (map :db/id @state)
+                            @state))
         group-label  label]
     [:div.mb-3
      [:label.form-label group-label]
@@ -273,6 +275,26 @@
      :value         @state
      :on-change     #(on-change (keyword (u/input-value %)))}]])
 
+(defmethod field-input :color
+  [{:keys [label disabled? autofocus? required? placeholder on-change state]
+    :or   {disabled? false required? false}}]
+  [:div.my-3
+   [:label.form-label {:for (u/sentence->kebab label)} label]
+   [:div.field-input__keywords
+    {:style {:display        :flex
+             :flex-flow      "row wrap"
+             :flex-direction :row
+             :margin-bottom  "5px"}}]
+   [:input.form-control
+    {:auto-focus    autofocus?
+     :disabled      disabled?
+     :required      required?
+     :placeholder   placeholder
+     :id            (u/sentence->kebab label)
+     :type          "color"
+     :value         @state
+     :on-change     #(on-change (u/input-value %))}]])
+
 
 ;;; Public Fns
 
@@ -286,7 +308,7 @@
   - :fields         A vector of field maps. Uses text fields by default. Field can have a `:type`
                     of: `:number` `:radio`, `:checkbox`.
   - :on-create      Takes a function which is passed the state in the editor, whose result is
-                    then to the default `:api/create-entity` event. Used to perform minor changes
+                    then to the default `:api/upsert-entity` event. Used to perform minor changes
                     before an entity is created.
   - :on-update      Like `:on-create` but only applies when the entity already exists.
 

--- a/projects/behave_cms/src/cljs/behave_cms/languages/subs.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/languages/subs.cljs
@@ -19,11 +19,6 @@
               :where
               [?e :language/shortcode "en-US"]]}))
 
-(comment
-  (rf/subscribe [:language/english-eid])
-
-  )
-
 ;;; Translations
 
 (rf/reg-sub

--- a/projects/behave_cms/src/cljs/behave_cms/languages/subs.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/languages/subs.cljs
@@ -11,6 +11,19 @@
    (rf/subscribe [:pull-with-attr :language/name]))
  identity)
 
+(rp/reg-sub
+  :language/english-eid
+  (fn [_ _]
+    {:type :query
+     :query '[:find ?e .
+              :where
+              [?e :language/shortcode "en-US"]]}))
+
+(comment
+  (rf/subscribe [:language/english-eid])
+
+  )
+
 ;;; Translations
 
 (rf/reg-sub

--- a/projects/behave_cms/src/cljs/behave_cms/lists/subs.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/lists/subs.cljs
@@ -1,5 +1,8 @@
 (ns behave-cms.lists.subs
-  (:require [re-frame.core :as rf]))
+  (:require
+   [clojure.set    :refer [rename-keys]]
+   [clojure.string :as str]
+   [re-frame.core  :as rf]))
 
 (rf/reg-sub
   :lists
@@ -7,3 +10,47 @@
     (rf/subscribe [:pull-with-attr :list/name '[* {:list/options [*]}]]))
   (fn [lists]
     (sort-by :list/name lists)))
+
+(def ^:private xform-tags #(rename-keys % {:tag/name :label :db/id :value}))
+
+(rf/reg-sub
+  :list-option/tags
+  (fn [[_ list-option-eid]]
+    (rf/subscribe [:pull '[{:list-option/tag-refs [*]}] list-option-eid]))
+  (fn [list-option]
+    (when-let [tags (:list-option/tag-refs list-option)]
+      (->> tags
+           (sort-by :tag/order)
+           (map :tag/name)
+           (str/join ", ")))))
+
+(rf/reg-sub
+  :list-option/color-tag
+  (fn [[_ list-option-eid]]
+    (rf/subscribe [:pull '[{:list-option/color-tag-ref [*]}] list-option-eid]))
+  (fn [list-option]
+    (-> list-option
+        (:list-option/color-tag-ref)
+        (:tag/name))))
+
+(rf/reg-sub
+  :list-option/tags-to-select
+  (fn [[_ list-eid]]
+    (rf/subscribe [:pull '[{:list/tag-set [*]}] list-eid]))
+  (fn [llist]
+    (->> llist
+         (:list/tag-set)
+         (:tag-set/tags)
+         (sort-by :tag/order)
+         (map xform-tags))))
+
+(rf/reg-sub
+  :list-option/color-tags-to-select
+  (fn [[_ list-eid]]
+    (rf/subscribe [:pull '[{:list/color-tag-set [*]}] list-eid]))
+  (fn [llist]
+    (->> llist
+         (:list/color-tag-set)
+         (:tag-set/tags)
+         (sort-by :tag/order)
+         (map xform-tags))))

--- a/projects/behave_cms/src/cljs/behave_cms/lists/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/lists/views.cljs
@@ -1,11 +1,11 @@
 (ns behave-cms.lists.views
-  (:require [re-frame.core                     :as rf]
+  (:require [clojure.set :refer [rename-keys]]
+            [re-frame.core                     :as rf]
             [behave-cms.components.common      :refer [simple-table]]
             [behave-cms.components.entity-form :refer [entity-form]]
             [behave-cms.events]
             [behave-cms.subs]
-            [behave-cms.components.translations :refer [all-translations]]
-            [clojure.string :as str]))
+            [behave-cms.components.translations :refer [all-translations]]))
 
 (defn- lists-table []
   (let [lists     (rf/subscribe [:pull-with-attr :list/name '[* {:list/options [*]}]])
@@ -20,45 +20,13 @@
      {:on-select on-select
       :on-delete on-delete}]))
 
-(defn- color-tags-table [llist]
-  (let [color-tags (->> (rf/subscribe [:pull-children :list/color-tags (:db/id llist)])
-                        deref
-                        (map (fn [option]
-                               (update option :list-option/color-tag
-                                       #(:color-tag/id @(rf/subscribe [:entity (:db/id %)]))))))
-        on-select  #(rf/dispatch [:state/set-state :color-tag %])
-        on-delete  #(when (js/confirm (str "Are you sure you want to delete the list " (:color-tag/id %) "?"))
-                      (rf/dispatch [:api/delete-entity %])
-                      (rf/dispatch [:state/set-state :color-tag nil]))]
-    [simple-table
-     [:color-tag/id]
-     color-tags
-     {:on-select on-select
-      :on-delete on-delete}]))
-
-(defn- color-tag-form [llist]
-  (let [*color-tag (rf/subscribe [:state :color-tag])]
-    [:<>
-     [:h3 (if @*color-tag "Edit Color Tag" "Add Color Tag")]
-     [entity-form {:entity       :color-tags
-                   :parent-field :list/_color-tags
-                   :parent-id    (:db/id list)
-                   :id           (:db/id @*color-tag)
-                   :on-create    #(-> %
-                                      (assoc :color-tag/translation-key (str "behaveplus:list:" (str/lower-case (:list/name llist)) ":color-tag:" (name (:color-tag/id %)))))
-                   :fields       [{:label     "Name"
-                                   :required? true
-                                   :type      :keyword
-                                   :field-key :color-tag/id}]}]
-     [:h4 "Translation"]
-     [all-translations (:color-tag/translation-key @*color-tag)]]))
-
 (defn- list-options-table [llist]
   (let [list-options (->> (rf/subscribe [:pull-children :list/options (:db/id llist)])
                           deref
                           (map (fn [option]
-                                 (update option :list-option/color-tag
-                                         #(:color-tag/id @(rf/subscribe [:entity (:db/id %)]))))))
+                                 (assoc option
+                                        :list-option/tags      @(rf/subscribe [:list-option/tags (:db/id option)])
+                                        :list-option/color-tag @(rf/subscribe [:list-option/color-tag (:db/id option)])))))
         on-select    #(rf/dispatch [:state/set-state :list-option %])
         on-delete    #(when (js/confirm (str "Are you sure you want to delete the list " (:list-option/name %) "?"))
                         (rf/dispatch [:api/delete-entity %])
@@ -75,11 +43,8 @@
 (defn- list-option-form [llist]
   (let [list-options      (rf/subscribe [:pull-children :list/options (:db/id llist)])
         *list-option      (rf/subscribe [:state :list-option])
-        color-tag-options (mapv (fn [{eid :db/id}]
-                                  (let [color-tag @(rf/subscribe [:entity eid])]
-                                    {:value eid
-                                     :label (:color-tag/id color-tag)}))
-                                (:list/color-tags llist))]
+        tag-options       (rf/subscribe [:list-option/tags-to-select (:db/id llist)])
+        color-tag-options (rf/subscribe [:list-option/color-tags-to-select (:db/id llist)])]
     [:<>
      [:h3 (if @*list-option "Edit Option" "Add Option")]
      [entity-form {:entity       :list-options
@@ -97,12 +62,15 @@
                                    :required? true
                                    :field-key :list-option/value}
                                   {:label     "Filter Tags"
-                                   :type      :keywords
-                                   :field-key :list-option/tags}
+                                   :type      :set
+                                   :is-ref?   true
+                                   :options   @tag-options
+                                   :field-key :list-option/tag-refs}
                                   {:label     "Color Tag"
                                    :type      :ref-select
-                                   :options   color-tag-options
-                                   :field-key :list-option/color-tag}
+                                   :disabled? (nil? (:list/color-tag-set llist))
+                                   :options   @color-tag-options
+                                   :field-key :list-option/color-tag-ref}
                                   {:label     "Hide Option?"
                                    :type      :checkbox
                                    :field-key :list-option/hide?
@@ -118,31 +86,35 @@
      [all-translations (:list-option/result-translation-key @*list-option)]]))
 
 (defn- list-form [llist]
-  [:<>
-   [:div.row
-    [:h3 (if llist (str "Edit " (:list/name llist)) "Add List")]]
-   [:div.row
-    [:div.col-3
-     [entity-form {:entity :lists
-                   :id     (when llist (:db/id llist))
-                   :fields [{:label     "Name"
-                             :required? true
-                             :field-key :list/name}]}]]]
-   [:div.row
-    [:div.col-4
-     [:h4 "Color Tags"]
-     [:div
-      {:style {:height "300px"}}
-      [color-tags-table llist]]]
-    [:div.col-8
-     [color-tag-form llist]]]
-   [:div.row
-    [:div.col-8
-     [:h4 "All Options"]
-     [:div {:style {:height "800px"}}
-      [list-options-table llist]]]
-    [:div.col-4
-     [list-option-form llist]]]])
+  (let [tag-sets        (rf/subscribe [:pull-with-attr :tag-set/name])
+        xform-tag-set   #(rename-keys % {:tag-set/name :label :db/id :value})
+        color-tag-sets  (map xform-tag-set (filter :tag-set/color? @tag-sets))
+        filter-tag-sets (map xform-tag-set (remove :tag-set/color? @tag-sets))]
+    [:<>
+     [:div.row
+      [:h3 (if llist (str "Edit " (:list/name llist)) "Add List")]]
+     [:div.row
+      [:div.col-3
+       [entity-form {:entity :lists
+                     :id     (when llist (:db/id llist))
+                     :fields [{:label     "Name"
+                               :required? true
+                               :field-key :list/name}
+                              {:label     "Filter Tag Set"
+                               :type      :ref-select
+                               :options   filter-tag-sets
+                               :field-key :list/tag-set}
+                              {:label     "Color Tag Set"
+                               :type      :ref-select
+                               :options   color-tag-sets
+                               :field-key :list/color-tag-set}]}]]]
+     [:div.row
+      [:div.col-8
+       [:h4 "All Options"]
+       [:div {:style {:height "800px"}}
+        [list-options-table llist]]]
+      [:div.col-4
+       [list-option-form llist]]]]))
 
 (defn list-lists-page [_]
   (let [loaded? (rf/subscribe [:state :loaded?])

--- a/projects/behave_cms/src/cljs/behave_cms/tags/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/tags/views.cljs
@@ -1,0 +1,116 @@
+(ns behave-cms.tags.views
+  (:require [re-frame.core                     :as rf]
+            [behave-cms.components.common      :refer [simple-table]]
+            [behave-cms.components.entity-form :refer [entity-form]]
+            [behave-cms.events]
+            [behave-cms.subs]
+            [string-utils.interface :refer [->kebab]]))
+
+;;; Helpers
+
+(defn- upsert-translation [t-key translation]
+  (let [english-eid @(rf/subscribe [:language/english-eid])]
+    {:translation/key         t-key
+     :language/_translation   english-eid
+     :translation/translation translation}))
+
+(defn- tag-editor [tag-set-eid tag-eid]
+  (let [tag-set (rf/subscribe [:entity tag-set-eid])
+        tags    (rf/subscribe [:pull-children :tag-set/tags tag-set-eid])]
+    [:<>
+     [:h3 (if tag-eid "Edit Tag" "Add Tag")]
+     [entity-form {:entity       :tag
+                   :parent-field :tag-set/_tags
+                   :parent-id    tag-set-eid
+                   :id           tag-eid
+                   :fields       [{:label     "Name"
+                                   :required? true
+                                   :field-key :tag/name}
+
+                                  {:label     "Color"
+                                   :type      :color
+                                   :disabled? (:tag-set/color? @tag-set)
+                                   :field-key :tag/color}]
+                   :on-create    (fn [data]
+                                   (let [translation (upsert-translation (:tag/translation-key data) (:tag/name data))]
+                                     (rf/dispatch [:api/create-entity translation])
+                                     (merge data {:tag/order (count @tags)})))
+                   :on-update    (fn [data]
+                                   (if (:tag/name data)
+                                     (let [translation (upsert-translation (:tag/translation-key data) (:tag/name data))]
+                                       (rf/dispatch [:api/create-entity translation])
+                                       data)
+                                     data))}]]))
+
+(defn- tags-table [tag-set-eid]
+  (when tag-set-eid
+    (let [tags      (rf/subscribe [:pull-children :tag-set/tags tag-set-eid])
+          on-select #(rf/dispatch [:state/select :tags (:db/id %)])
+          on-delete
+          #(when (js/confirm (str "Are you sure you want to delete the tag " (:tag/name %) "?"))
+             (rf/dispatch [:api/delete-entity %]))]
+      [:div
+       {:style {:height "400px"}}
+       [simple-table
+        [:tag/name]
+        (sort-by :tag/order @tags)
+        {:on-select on-select
+         :on-delete on-delete
+         :on-increase #(rf/dispatch [:api/reorder % @tags :tag/order :inc])
+         :on-decrease #(rf/dispatch [:api/reorder % @tags :tag/order :dec])}]])))
+
+;;; Dimension
+
+(defn- tag-set-editor [tag-set-eid tag-eid]
+  [:<>
+   [:div.row
+    [:h3 (str (if tag-set-eid "Edit" "Add") " Tag-Set")]]
+   [:div.row
+    [:div.col-6
+     [entity-form {:entity    :tag-sets
+                   :id        tag-set-eid
+                   :disabled? (boolean tag-eid)
+                   :fields    [{:label     "Name"
+                                :required? true
+                                :field-key :tag-set/name}
+
+                               {:label     "Colored Tags?"
+                                :type      :checkbox
+                                :field-key :tag-set/color?
+                                :options   [{:value true}]}]
+                   :on-create (fn [data]
+                                (let [translation-key (str "behaveplus:tags:" (->kebab (:tag-set/name data)))
+                                      translation     (upsert-translation translation-key (:tag-set/name data))]
+                                  (rf/dispatch [:api/create-entity translation])
+                                  (merge data {:tag-set/translation-key translation-key})))}]]]])
+
+(defn- tag-sets-table []
+  (let [tag-sets (rf/subscribe [:pull-with-attr :tag-set/name])
+        on-select  #(rf/dispatch [:state/select :tag-sets (:db/id %)])
+        on-delete  #(when (js/confirm (str "Are you sure you want to delete the tag set " (:tag-set/name %) "?"))
+                      (rf/dispatch [:api/delete-entity %]))]
+    [:div
+     {:style {:height "400px"}}
+     [simple-table
+      [:tag-set/name]
+      (sort-by :tag-set/name @tag-sets)
+      {:on-select on-select
+       :on-delete on-delete}]]))
+
+(defn tags-page [_]
+  (let [*tag-set (rf/subscribe [:selected :tag-sets])
+        *tag      (rf/subscribe [:selected :tags])]
+    [:div.container
+     [:div.row.mt-3
+      [:h3 "Tag-Sets / Tags"]
+      [:div.row
+       [:div.col-6
+        [tag-sets-table]]
+       [:div.col-6
+        [tags-table @*tag-set]]]]
+     [:div.row.mt-3
+      [:div.col-6
+       [tag-set-editor @*tag-set @*tag]]
+      [:div.col-6
+       (when @*tag-set
+         [tag-editor @*tag-set @*tag])]]]))


### PR DESCRIPTION
---

## Purpose
* Creates new `:tag-set/*`, `:tags/*` schema to hand both filter tags
and color/category tags
* Creates new `/tags` page in the VMS the create, update Tag Sets/Tags
* Updates multi-select component to allow `filter-tags` and
`color-tags` to be passed in, rather than pulling from the options.
* Updates app to use new tags, including updating proper subscriptions
* Adds migration to migrate existing tags

## Related Issues
Closes [BHP1-1238](https://sig-gis.atlassian.net/browse/BHP1-1238)

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [z] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [z] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Pull down latest, start App/VMS
2. Run Migration `migrations.2025-04-05-migrate-list-tags`
3. Verify that the following Tag Sets exist in the VMS:
  * Fuel Types
  * Fuel Region Categories
  * Region Codes
4. Verify in the VMS that the following Lists have both Tags/Color
   Tags assigned:
   * SurfaceFuelModels
   * WindDrivenSurfaceFuelModelCodes
   * MortalitySpeciesMasterList
5. Verify in the App that the order of the Multi-Select under Surface >
   Inputs > Fuel Models is in the following order:
   1. Grass
   1. Grass Shrub
   1. Shrub
   1. Timber Understory
   1. Timber Litter
   1. Slash Blowdown

## Screenshots

<img width="1130" alt="Screenshot 2025-04-10 at 11 06 17" src="https://github.com/user-attachments/assets/3f377745-94ef-47c7-882a-dee6db7b917a" />


[BHP1-1238]: https://sig-gis.atlassian.net/browse/BHP1-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ