### PR TITLE
[BHP1-1269] Hide Unused Toolbar Icons for now

### DIFF
--- a/projects/behave/src/cljs/behave/components/toolbar.cljs
+++ b/projects/behave/src/cljs/behave/components/toolbar.cljs
@@ -184,20 +184,20 @@
                   {:icon     :share
                    :label    (bp "share")
                    :on-click #(rf/dispatch [:dev/export-from-vms])}
-                  {:icon     :zoom-in
-                   :label    (bp "zoom-in")
-                   :on-click on-click}
-                  {:icon     :zoom-out
-                   :label    (bp "zoom-out")
-                   :on-click on-click}]]
+                  #_{:icon     :zoom-in
+                     :label    (bp "zoom-in")
+                     :on-click on-click}
+                  #_{:icon     :zoom-out
+                     :label    (bp "zoom-out")
+                     :on-click on-click}]]
     [:div.toolbar
      [:div.toolbar__tools
       (for [tool tools]
         ^{:key (:label tool)}
         [toolbar-tool tool])
-      [c/text-input {:disabled?   false
-                     :error?      false
-                     :focused?    false
-                     :placeholder "Search"}]]
+      #_[c/text-input {:disabled?   false
+                       :error?      false
+                       :focused?    false
+                       :placeholder "Search"}]]
      (when @*loaded?
        [progress-bar params])]))


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1269

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open App, Ensure the zoom out, zoom in, and search bar is no longer showing in the toolbar

## Screenshots