### PR TITLE
fix color tag from erroring when a second input is selected

### DIFF
--- a/bases/behave_components/src/cljs/behave/components/inputs.cljs
+++ b/bases/behave_components/src/cljs/behave/components/inputs.cljs
@@ -171,16 +171,17 @@
 ;;==============================================================================
 
 (defn- multi-select-option [{:keys [selected? label on-click color-tag]}]
-  [:div (cond-> {:class    ["multi-select__option"
-                            (when selected? "multi-select__option--selected")
-                            (when color-tag "multi-select__option__color-tag")]
-                 :style    {}
-                 :on-click on-click}
-          color-tag
-          (assoc-in [:style :border-color] (:color color-tag)))
-   [:div {:class [(if selected? "multi-select__option__icon--minus" "multi-select__option__icon--plus")]}
-    [icon (if selected? "minus" "plus")]]
-   label])
+  (let [color (:color color-tag)]
+    [:div (cond-> {:class    ["multi-select__option"
+                              (when selected? "multi-select__option--selected")
+                              (when color-tag "multi-select__option__color-tag")]
+                   :style    {}
+                   :on-click on-click}
+            color-tag
+            (assoc-in [:style :border-color] color))
+     [:div {:class [(if selected? "multi-select__option__icon--minus" "multi-select__option__icon--plus")]}
+      [icon (if selected? "minus" "plus")]]
+     label]))
 
 (defn multi-select-input
   "Creates a multi-select input component with the following options:


### PR DESCRIPTION
-------

## Purpose

There's an odd behavior in the application when selecting a second fuel model code causes the application to error out. This should fix it.

## Related Issues
Closes BHP1-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open local App
2. Create Surface worksheet
3. Select Outputs:

Direction Mode > Heading
Surface Fire > Rate of Spread

4. Navigate to Inputs > Fuel Model
5. Click "Select More"
6. Select 2 or more fuel models. Ensure the application does not go blank on the second selection.

## Screenshots