### PR TITLE
[BHP1-1277] Fix Multi Select

### DIFF
--- a/bases/behave_components/src/cljs/behave/components/inputs.cljs
+++ b/bases/behave_components/src/cljs/behave/components/inputs.cljs
@@ -200,8 +200,8 @@
   [{:keys [input-label options filter-tags color-tags]}]
   (r/with-let [selections (r/atom (->> options
                                        (filter #(true? (:selected? %)))
-                                       (map (fn [{:keys [label value on-deselect color-tag]}]
-                                              [label value on-deselect color-tag]))
+                                       (map (fn [{:keys [label value on-deselect]}]
+                                              [label value on-deselect]))
                                        (into (sorted-set))))
                show-options? (r/atom false)
                selected-tag (r/atom nil)]
@@ -241,7 +241,7 @@
                                       (and filter-tags @selected-tag)
                                       (filter (fn [id] (contains? (:tags id) @selected-tag))))]
             ^{:key label}
-            (let [selection [label value on-deselect color-tag]]
+            (let [selection [label value on-deselect]]
               [multi-select-option {:selected? (contains? @selections selection)
                                     :color-tag color-tag
                                     :label     label


### PR DESCRIPTION
-------

## Purpose

Multi select errors out on a second selection.

The issue is with the selections atom. Since some selections don't have color-tag it cant compare it inside a sorted-set. Fix here is to remove the color tag from the selections, this is not needed to keep track of what is being selected.

## Related Issues
Closes BHP1-1277

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open a surface worksheet and navigate to inputs page
2. Select at least 2 or more fuel models. Ensure the application does not go blank on the second selection

## Screenshots