### PR TITLE
[BHP1-1280] Fix Multi Discrete Input order in Review and Result Page

### DIFF
--- a/projects/behave/src/cljs/behave/components/review_input_group.cljs
+++ b/projects/behave/src/cljs/behave/components/review_input_group.cljs
@@ -73,8 +73,10 @@
                                          repeat-id
                                          _repeat-group?
                                          edit-route]
-  (let [*value               (rf/subscribe [:worksheet/input-value ws-uuid group-uuid repeat-id gv-uuid])
+  (let [list-eid             @(rf/subscribe [:vms/gv-uuid->list-eid gv-uuid])
+        *value               (rf/subscribe [:worksheet/input-value ws-uuid group-uuid repeat-id gv-uuid])
         resolved-enum-values (->> (str/split @*value ",")
+                                  (sort-by #(deref (rf/subscribe [:worksheet/resolve-enum-order list-eid %])))
                                   (map #(deref (rf/subscribe [:worksheet/resolve-enum-value eid %]))))]
     [:div.wizard-input {:on-mouse-over #(rf/dispatch [:help/highlight-section help-key])}
      [:div.wizard-review__input

--- a/projects/behave/src/cljs/behave/vms/subs.cljs
+++ b/projects/behave/src/cljs/behave/vms/subs.cljs
@@ -188,3 +188,14 @@
           [?gv :bp/uuid ?gv-uuid]
           [?gv :group-variable/discrete-multiple? ?discrete-multiple]]
         @@vms-conn gv-uuid)))
+
+(reg-sub
+ :vms/gv-uuid->list-eid
+ (fn [_ [_ gv-uuid]]
+   (d/q '[:find ?l .
+          :in $ ?gv-uuid
+          :where
+          [?gv :bp/uuid ?gv-uuid]
+          [?v :variable/group-variables ?gv]
+          [?v :variable/list ?l]]
+        @@vms-conn gv-uuid)))

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -980,6 +980,16 @@
        value))))
 
 (rf/reg-sub
+ :worksheet/resolve-enum-order
+
+ (fn [_ [_ list-eid value]]
+   (let [list-entity             (d/touch (d/entity @@vms-conn list-eid))
+         {options :list/options} list-entity
+         options                 (index-by :list-option/value options)
+         option                  (get options value)]
+     (:list-option/order option))))
+
+(rf/reg-sub
  :worksheet/result-table-gv-uuid->units
  (fn [_ [_ ws-uuid]]
    (let [gv-uuids+units (d/q '[:find  ?gv-uuid ?units


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1280

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Create a Surface worksheet
2. Select Outputs:

- Direciton Mode > Heading
- Surface Fire > Rate of Spread

3. Navigate to Inputs > Fuel Model
4. Select Multiple Fuel models in random order.
5. Complete the worksheet and navigate to Review page
6. Ensure Fuel Model Codes are ordered as expected
7. Run the worksheet
8. Navigate to results page.
9. Ensure Fuel Model Codes are ordered as expected in the inputs table

## Screenshots