### PR TITLE
[BHP1-1286] Default Graph Settings to True When Needed

### DIFF
--- a/projects/behave/src/cljs/behave/wizard/subs.cljs
+++ b/projects/behave/src/cljs/behave/wizard/subs.cljs
@@ -850,3 +850,15 @@
  (fn [[_ ws-uuid]] (subscribe [:wizard/multi-value-input-count ws-uuid]))
  (fn [count _]
    (pos? count)))
+
+(reg-sub
+ :wizard/enable-graph-settings?
+ (fn [[_ ws-uuid]]
+   [(subscribe [:worksheet/get-graph-settings-attr
+                ws-uuid
+                :graph-settings/enabled?])
+    (subscribe [:worksheet/multi-value-input-uuids ws-uuid])])
+ (fn [[saved-enabled?-setting multi-valued-inputs] _]
+   (if (not (nil? (first saved-enabled?-setting)))
+     (first saved-enabled?-setting)
+     (pos? (count multi-valued-inputs)))))

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -439,13 +439,14 @@
   (let [*multi-value-input-uuids (subscribe [:worksheet/multi-value-input-uuids ws-uuid])
         group-variables          (->> @*multi-value-input-uuids
                                       (map #(deref (subscribe [:wizard/group-variable %]))))
-        enabled?                 (first @(subscribe [:worksheet/get-graph-settings-attr
-                                                     ws-uuid
-                                                     :graph-settings/enabled?]))
         multi-valued-input-uuids @(subscribe [:worksheet/multi-value-input-uuids ws-uuid])
         multi-valued-input-count (count multi-valued-input-uuids)
         x-axis-limits            (first @(subscribe [:worksheet/graph-settings-x-axis-limits ws-uuid]))
-        units-lookup                   @(subscribe [:worksheet/result-table-units ws-uuid])]
+        units-lookup             @(subscribe [:worksheet/result-table-units ws-uuid])
+        saved-enabled?-setting   (first @(subscribe [:worksheet/get-graph-settings-attr
+                                                     ws-uuid
+                                                     :graph-settings/enabled?]))
+        enabled?                 (or saved-enabled?-setting (pos? multi-valued-input-count))]
     (letfn [(radio-group [{:keys [label attr variables on-change]}]
               (let [*values   (subscribe [:worksheet/get-graph-settings-attr ws-uuid attr])
                     selected? (first @*values)]

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -446,7 +446,9 @@
         saved-enabled?-setting   (first @(subscribe [:worksheet/get-graph-settings-attr
                                                      ws-uuid
                                                      :graph-settings/enabled?]))
-        enabled?                 (or saved-enabled?-setting (pos? multi-valued-input-count))]
+        enabled?                 (if (not (nil? saved-enabled?-setting))
+                                   saved-enabled?-setting
+                                   (pos? multi-valued-input-count))]
     (letfn [(radio-group [{:keys [label attr variables on-change]}]
               (let [*values   (subscribe [:worksheet/get-graph-settings-attr ws-uuid attr])
                     selected? (first @*values)]

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -443,12 +443,7 @@
         multi-valued-input-count (count multi-valued-input-uuids)
         x-axis-limits            (first @(subscribe [:worksheet/graph-settings-x-axis-limits ws-uuid]))
         units-lookup             @(subscribe [:worksheet/result-table-units ws-uuid])
-        saved-enabled?-setting   (first @(subscribe [:worksheet/get-graph-settings-attr
-                                                     ws-uuid
-                                                     :graph-settings/enabled?]))
-        enabled?                 (if (not (nil? saved-enabled?-setting))
-                                   saved-enabled?-setting
-                                   (pos? multi-valued-input-count))]
+        enabled?                 @(subscribe [:wizard/enable-graph-settings? ws-uuid])]
     (letfn [(radio-group [{:keys [label attr variables on-change]}]
               (let [*values   (subscribe [:worksheet/get-graph-settings-attr ws-uuid attr])
                     selected? (first @*values)]

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -427,7 +427,9 @@
    (let [graph-setting-id (get-in worksheet [:worksheet/graph-settings :db/id])
          enabled?         (get-in worksheet [:worksheet/graph-settings :graph-settings/enabled?])]
      {:transact [{:db/id                   graph-setting-id
-                  :graph-settings/enabled? (not enabled?)}]
+                  :graph-settings/enabled? (if (nil? enabled?)
+                                             false
+                                             (not enabled?))}]
       :fx       [[:dispatch [:worksheet/set-default-graph-settings ws-uuid]]]})))
 
 (rp/reg-event-fx


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1286

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open local app and create a worksheet
2. Fill in worksheets but with no multi valued inputs
3. Run worksheet
4. Navigate to Settings page
5. Ensure the graph settings DO NOT show (this should be as before)
6. Go back to inputs and change one to a multi valued input
7. Re run worksheet and navigate to settings page
8. Ensure the graph settings section is now shown and that it is enabled by default (new behavior).

## Screenshots