### PR TITLE
[BHP1-1301] Fix PDF not showing for multi-range inputs

### DIFF
--- a/projects/behave/src/cljs/behave/store.cljs
+++ b/projects/behave/src/cljs/behave/store.cljs
@@ -85,7 +85,7 @@
         (swap! sync-txs union (txs datoms))
         (d/transact @conn datoms)))))
 
-(defn sync-latest-datoms! []
+(defn- sync-latest-datoms! []
   (ajax-request {:uri             "/sync"
                  :params          {:tx (:max-tx @@conn)}
                  :method          :get
@@ -192,3 +192,8 @@
  :ds/transact
  (fn [_ [_ tx-data]]
    (first tx-data)))
+
+(rp/reg-event-ds
+ :ds/transact-many
+ (fn [_ [_ tx-data]]
+   tx-data))


### PR DESCRIPTION
-------

## Purpose
Reconfigures the `behave.solver.table` namespace to use a
"migration"-style transaction to reduce the number of transactions
when creating the results table, therefore removing the need for
introducing complicated queuing/back-pressure for hundreds of thousands
of tx's for multiple ranged inputs.

## Related Issues
Closes [BHP1-1301](https://sig-gis.atlassian.net/browse/BHP1-1301)

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Start Dev App
2. Load & run worksheet from BHP1-1301 ticket
3. Run the worksheet
4. Verify that the PDF now shows the graphs