### PR TITLE
[BHP1-1326] Fix Hanging Compute

### DIFF
--- a/projects/behave/src/cljs/behave/solver/table.cljs
+++ b/projects/behave/src/cljs/behave/solver/table.cljs
@@ -41,17 +41,21 @@
 
         ;; Multiple Groups w/ Single Variable
         (every? #(= 1 (count %)) (vals repeats))
-        (for [[repeat-id [_ repeat-group]] (map list repeats (range (count repeats)))]
+        (doseq [[repeat-id [_ repeat-group]] (map list repeats (range (count repeats)))]
           (let [[gv-id [_value unit-uuid]] (first repeat-group)
-                units                     (unit-label unit-uuid)]
+                units                      (unit-label unit-uuid)]
             (swap! headers conj [gv-id repeat-id units])))
 
         ;; Multiple Groups w/ Multiple Variables
         :else
-        (for [[[_ repeat-group] repeat-id] (map list repeats (range (count repeats)))]
-          (doseq [[gv-id [_value unit-uuid]] repeat-group]
-            (let [units (unit-label unit-uuid)]
-              (swap! headers conj [gv-id repeat-id units]))))))
+        (doseq [[gv-id repeat-id unit-uuid] (mapcat (fn [[repeat-id r]]
+                                                      (map
+                                                       (fn [[gv-id [_value units]]]
+                                                         [gv-id repeat-id units])
+                                                       r))
+                                                    repeats)]
+          (let [units (unit-label unit-uuid)]
+            (swap! headers conj [gv-id repeat-id units])))))
     (concat @headers
             (mapv (fn [[gv-id [_ unit-uuid]]]
                     (let [units (unit-label unit-uuid)]

--- a/projects/behave/src/cljs/behave/wizard/subs.cljs
+++ b/projects/behave/src/cljs/behave/wizard/subs.cljs
@@ -845,6 +845,20 @@
  (fn [_ [_ gv-uuid]]
    (group-variable-discrete? gv-uuid)))
 
+(defn- group-variable-text?
+  [gv-uuid]
+  (= (d/q '[:find  ?kind .
+            :in    $ % ?gv-uuid
+            :where
+            (variable-kind ?gv-uuid ?kind)]
+          @@vms-conn rules gv-uuid)
+     :text))
+
+(reg-sub
+ :wizard/text-group-variable?
+ (fn [_ [_ gv-uuid]]
+   (group-variable-text? gv-uuid)))
+
 (reg-sub
  :wizard/show-graph-settings?
  (fn [[_ ws-uuid]] (subscribe [:wizard/multi-value-input-count ws-uuid]))

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -395,7 +395,7 @@
    (->> inputs
         (filter (fn multiple-values? [[gv-uuid value]]
                   (and
-                   (not (rf/subscribe [:wizard/text-group-variable? gv-uuid]))
+                   (not @(rf/subscribe [:wizard/text-group-variable? gv-uuid]))
                    (> (count (str/split value #",|\s"))
                       1)))))))
 

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -393,9 +393,11 @@
 
  (fn [inputs _query]
    (->> inputs
-        (filter (fn multiple-values? [[_uuid value]]
-                  (> (count (str/split value #",|\s"))
-                     1))))))
+        (filter (fn multiple-values? [[gv-uuid value]]
+                  (and
+                   (not (rf/subscribe [:wizard/text-group-variable? gv-uuid]))
+                   (> (count (str/split value #",|\s"))
+                      1)))))))
 
 (rf/reg-sub
  :worksheet/multi-value-input-uuids


### PR DESCRIPTION
## Purpose

The laziness was causing headers group variables to be omitted from the map of headers. Using `doseq` to fix this.

## Related Issues
Closes BHP1-1326

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open this worksheet re-run: 
[Surf&Contain_Resources.zip](https://github.com/user-attachments/files/20511644/Surf.Contain_Resources.zip)


2. Open this worksheet re-run:
[Surface&Crown.zip](https://github.com/user-attachments/files/20511646/Surface.Crown.zip)


## Screenshots