### PR TITLE
[BHP1-1294] Add Migration to rename Torching Tree Species

### DIFF
--- a/development/migrations/2025_06_02_fix_torching_tree_species.clj
+++ b/development/migrations/2025_06_02_fix_torching_tree_species.clj
@@ -1,0 +1,88 @@
+(ns migrations.2025-06-02-fix-torching-tree-species
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; Renames Torching Tree Species
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def columns [:species :latin :common])
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def tree-species
+  (->> ["PIEN" "Picea engelmannii" "Engelmann spruce"
+        "PSME" "Pseudotsuga menziesii" "Douglas-fir"
+        "ABLA" "Abies lasiocarpa" "Subalpine fir"
+        "TSHE" "Tsuga heterophylla" "Western hemlock"
+        "PIPO" "Pinus ponderosa" "Ponderosa pine"
+        "PICO" "Pinus contorta" "Lodgepole pine"
+        "PIMO3" "Pinus monticola" "Western white pine"
+        "ABGR" "Abies grandis" "Grand fir"
+        "ABBA" "Abies balsamea" "Balsam fir"
+        "PIEL" "Pinus elliottii" "Slash pine"
+        "PIPA2" "Pinus palustris" "Longleaf pine"
+        "PISE" "Pinus serotina" "Pond pine"
+        "PIEC2" "Pinus echinata" "Shortleaf pine"
+        "PITA" "Pinus taeda" "Loblolly pine"]
+       (partition 3)
+       (map (fn [c1 c2] (apply assoc {} (interleave c1 c2))) (repeat columns))))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def existing-species 
+  (d/q '[:find ?o ?o-name
+         :keys id existing
+         :where
+         [?l :list/name "TreeSpeciesSpot"]
+         [?l :list/options ?o]
+         [?o :list-option/name ?o-name]]
+       (d/db conn)))
+
+(defn- new-name
+  [{:keys [id existing]}]
+  (let [[_ common latin]  (re-find #"(.*) \((.*)\)" existing)
+        {:keys [species]} (filter #(= (:common %) common) tree-species)]
+    {:species          species
+     :db/id            id
+     :list-option/name (format "%s / %s (%s)" latin species common)}))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload 
+  (->> (map new-name existing-species)
+       (sort-by :species)
+       (map-indexed (fn [idx m]
+                      (-> m
+                          (assoc :list-option/order idx)
+                          (dissoc :species))))))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (try (def tx-data @(d/transact conn payload))
+       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))


### PR DESCRIPTION
-------

## Purpose
Rename and re-order Torching Tree Species

## Related Issues
Closes BHP1-1294

## Submission Checklist
- [ ] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [ ] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Start local VMS and App
2. Run migration `migrations.2025-06-02-fix-torching-tree-species`
3. Sync App 
4. Start a "Surface" worksheet 
5. Select "Outputs > Spot > Max Spotting Distance from Torching Trees" 
6. Verify that Tree Species are of the form: `Latin name / CODE (Common
   name)` (e.g. `Abies balsamea / ABBA (Balsam fir)`)
7. Verify that Tree Species are ordered by their species code.

## Screenshots