### PR TITLE
[BHP1-1311] Update Spot Input Flame Length Translations

### DIFF
--- a/components/schema_migrate/src/schema_migrate/interface.clj
+++ b/components/schema_migrate/src/schema_migrate/interface.clj
@@ -82,6 +82,10 @@
                   the same transaction where you've manually assigned :db/id)."}
   build-translations-payload c/build-translations-payload)
 
+(def ^{:arglists '([conn eid-start t-key->translation-map])
+       :doc      "Creates a payload to update existing translations for specific language shortcode."}
+  update-translations-payload c/update-translations-payload)
+
 (def ^{:arglists '([conn t-key])
        :doc      "Removes an entity's (and it's components) translation keys."}
   remove-nested-i18ns-tx c/remove-nested-i18ns-tx)

--- a/development/migrations/2025_06_12_spot_flame_length_translation.clj
+++ b/development/migrations/2025_06_12_spot_flame_length_translation.clj
@@ -1,0 +1,36 @@
+(ns migrations.2025-06-12-spot-flame-length-translation
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload
+  (sm/update-translations-payload
+   conn
+   "en-US"
+   {"behaveplus:crown:input:spotting:fire_behavior:active_crown_flame_length"                           "Flame Length"
+    "behaveplus:crown:input:spotting:fire_behavior:active_crown_flame_length:active_crown_flame_length" "Flame Length"}))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  (def tx-data (d/transact conn payload)))
+
+;; ===========================================================================================================
+;; Rollback
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))


### PR DESCRIPTION
-------

## Purpose
- Updates the name of the input for "Flame Length" for Crown Spot > Torching Trees 
- Adds a new `sm/update-translations-payload` function to update
  existing translations.

## Related Issues
Closes BHP1-1311

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Load VMS, run migration `migrations.2025-06-12-spot-flame-length-translation`
2. Load App, sync
3. Select "Surface & Crown" Worksheet
4. Select "Spot > Torching Trees" as only output
5. Verify that under "Inputs > Spot > Fire Behavior" that the Group
   name has been renamed to "Flame Length"