### PR TITLE
[BHP1-1313] Rename 'Tools' to 'Calculators'

### DIFF
--- a/development/migrations/2025_06_23_rename_tools_to_calculators.clj
+++ b/development/migrations/2025_06_23_rename_tools_to_calculators.clj
@@ -1,0 +1,72 @@
+(ns migrations.2025-06-23-rename-tools-to-calculators
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; 1. Rename "Tools" to "Calculators":
+;;   - Main menu should say Calculators & Settings
+;;   - Button should say Calculators (plural)
+;;   - Header in the selection window should say Select a Calculator
+;;   - Close button says Close Calculator
+;;
+;; 2. Rename tool names for clarity:
+;;   - Ignite → Probability of Ignition
+;;   - 1-HR Fuel Moisture → 1-Hour Fuel Moisture
+;;   - Slope Tool → Slope from Map Measurements
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def new-translations
+  (sm/build-translations-payload
+   conn
+   100
+   {"behaveplus:calculators"              "Calculators"
+    "behaveplus:calculators_and_settings" "Calculators & Settings"
+    "behaveplus:close_calculator"         "Close Calculator"
+    "behaveplus:select_calculator"        "Select a Calculator"
+    "behaveplus:select"                   "Select..."}))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def rename-tools-payload
+  [{:bp/nid    "8F_7EmeSVZ5LWVW5D37XQ"
+    :tool/name "Probability of Ignition"}
+   {:bp/nid    "SuQVp1yhgrpTme2PZ8yxr"
+    :tool/name "1-Hour Fuel Moisture"}
+   {:bp/nid    "0M1P3z24kkvsTBYrSgsRf"
+    :tool/name "Slope from Map Measurements"}])
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload (concat rename-tools-payload new-translations))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (try (def tx-data @(d/transact conn payload))
+       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))
+

--- a/projects/behave/src/cljs/behave/components/sidebar.cljs
+++ b/projects/behave/src/cljs/behave/components/sidebar.cljs
@@ -80,8 +80,8 @@
                                      :module    #{:mortality}}])}]]
 
        [:div.sidebar-container__tools-settings
-        [sidebar-group {:title   @(<t (bp "tools_and_settings"))
-                        :modules [{:label     "behaveplus:calculator"
+        [sidebar-group {:title   @(<t (bp "calculators_and_settings"))
+                        :modules [{:label     "behaveplus:calculators"
                                    :icon      "calculator"
                                    :on-select #(rf/dispatch [:state/set [:sidebar :*tools-or-settings] :tools])}
                                   {:label     "behaveplus:settings"

--- a/projects/behave/src/cljs/behave/tool/views.cljs
+++ b/projects/behave/src/cljs/behave/tool/views.cljs
@@ -11,7 +11,7 @@
   "A Modal used for selecting a tool"
   []
   (let [tools @(rf/subscribe [:tool/all-tools])]
-    [c/modal {:title          "Select Tools"
+    [c/modal {:title          @(<t (bp "select_calculator"))
               :close-on-click #(rf/dispatch [:tool/close-tool-selector])
               :content        [c/card-group {:on-select      #(rf/dispatch [:tool/select-tool (:uuid %)])
                                              :flex-direction "column"
@@ -119,7 +119,7 @@
          :label     var-name
          :on-change on-change
          :name      (->kebab var-name)
-         :options   (concat [{:label "Select..." :value "nil"}]
+         :options   (concat [{:label @(<t (bp "select")) :value "nil"}]
                             (map ->option options))}])]))
 
 (defn- tool-output
@@ -168,7 +168,7 @@
        (if (= io :input)
          [tool-input params]
          [tool-output params]))
-     [c/button {:label         @(<t (bp "close_tool"))
+     [c/button {:label         @(<t (bp "close_calculator"))
                 :variant       "secondary"
                 :icon-name     "close"
                 :icon-position "right"
@@ -194,7 +194,7 @@
          :tool-uuid     tool-uuid
          :subtool-uuid  subtool-uuid
          :auto-compute? false}])
-     [c/button {:label         @(<t (bp "close_tool"))
+     [c/button {:label         @(<t (bp "close_calculator"))
                 :variant       "secondary"
                 :icon-name     "close"
                 :icon-position "right"


### PR DESCRIPTION
-------

## Purpose
1. Rename "Tools" to "Calculators":
  - Main menu should say Calculators & Settings
  - Button should say Calculators (plural)
  - Header in the selection window should say Select a Calculator
  - Close button says Close Calculator

2. Rename tool names for clarity:
  - Ignite → Probability of Ignition
  - 1-HR Fuel Moisture → 1-Hour Fuel Moisture
  - Slope Tool → Slope from Map Measurements

## Related Issues
Closes BHP1-1313

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Start VMS
2. Run migration `migrations.2025-06-23-rename-tools-to-calculators`
3. Start App, Sync
4. Verify that translations have been updated to use 'Calculators'
5. Open 'Calculators', verify that calculators have been renamed

## Screenshots

<img width="201" alt="Screenshot 2025-06-23 at 10 34 25" src="https://github.com/user-attachments/assets/92a09a53-09b8-4d91-b131-9edbdb70ee80" />
<img width="571" alt="Screenshot 2025-06-23 at 10 34 28" src="https://github.com/user-attachments/assets/7f9e0492-a85e-44aa-9476-81d9a9c9e3bd" />
