### PR TITLE
[BHP1-1285] Adds list option export translation key

### DIFF
--- a/bases/behave_schema/src/behave/schema/list.cljc
+++ b/bases/behave_schema/src/behave/schema/list.cljc
@@ -129,6 +129,12 @@
     :db/cardinality :db.cardinality/one
     :db/unique      :db.unique/identity}
 
+   {:db/ident       :list-option/export-translation-key
+    :db/doc         "List option's translation key for export."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+
    {:db/ident       :list-option/hide?
     :db/doc         "Used to hid a list option."
     :db/valueType   :db.type/boolean

--- a/development/migrations/2025_06_25_add_moisture_scenario_export_translations.clj
+++ b/development/migrations/2025_06_25_add_moisture_scenario_export_translations.clj
@@ -1,0 +1,83 @@
+(ns migrations.2025-06-25-add-moisture-scenario-export-translations
+  (:require [clojure.string :as str]
+            [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def moisture-scenarios-list-options
+  (d/q '[:find [(pull ?o [:db/id :list-option/name :list-option/result-translation-key]) ...]
+         :in $ ?list-name
+         :where
+         [?l :list/name ?list-name]
+         [?l :list/options ?o]]
+       (d/db conn) "MoistureScenarios"))
+
+(defn- remove-non-alphanumeric
+  [s]
+  (apply str (filter #(re-matches #"[a-zA-Z0-9\-:]" (str %)) s)))
+
+(defn- export-translation-key [option]
+  (-> (:list-option/result-translation-key option)
+      (str/replace-first #"result" "export")
+      (remove-non-alphanumeric)
+      (str/replace #"-\d+$" "")))
+
+(defn- add-export-translation-key [option]
+  (assoc option :list-option/export-translation-key (export-translation-key option)))
+
+(defn- ->export-translation [option]
+  (let [option-name    (:list-option/name option)
+        [_ short-code] (re-matches #"^([A-Z0-9]+) .*" option-name)]
+    [(:list-option/export-translation-key option) short-code]))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def list-options-with-export-translation-keys
+  (map add-export-translation-key moisture-scenarios-list-options))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def export-translation-keys-payload
+  (map #(select-keys % [:db/id :list-option/export-translation-key]) list-options-with-export-translation-keys))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def create-export-translations-payload
+  (sm/build-translations-payload
+   conn 
+   100
+   (into {} (map ->export-translation list-options-with-export-translation-keys))))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload (concat [] export-translation-keys-payload create-export-translations-payload))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  (try (def tx-data @(d/transact conn payload))
+       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/development/migrations/2025_06_25_default_export_translation_key.clj
+++ b/development/migrations/2025_06_25_default_export_translation_key.clj
@@ -1,0 +1,69 @@
+(ns migrations.2025-06-25-default-export-translation-key
+  (:require [clojure.string :as str]
+            [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def list-options
+  (d/q '[:find [(pull ?o [:db/id :list-option/result-translation-key]) ...]
+         :in $ ?moisture-list-name
+         :where
+         [?l :list/name ?list-name]
+         [(not= ?list-name ?moisture-list-name)]
+         [?l :list/options ?o]
+         [?o :list-option/result-translation-key ?k]]
+       (d/db conn) "MoistureScenarios"))
+
+(defn- remove-non-alphanumeric
+  [s]
+  (apply str (filter #(re-matches #"[a-zA-Z0-9\-:]" (str %)) s)))
+
+(defn- export-translation-key [option]
+  (-> (:list-option/result-translation-key option)
+      (str/replace-first #"result" "export")
+      (remove-non-alphanumeric)))
+
+(defn- add-export-translation-key [option]
+  (assoc option :list-option/export-translation-key (export-translation-key option)))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def list-options-with-export-translation-keys
+  (map add-export-translation-key list-options))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload 
+  (map #(select-keys % [:db/id :list-option/export-translation-key]) list-options-with-export-translation-keys))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  (try (def tx-data @(d/transact conn payload))
+       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -566,17 +566,21 @@
             significant-digits (or @*cached-decimals (:domain/decimals domain))]
         (fn continuous-fmt [value]
           (cond->> value
-            :always            (parse-float)
+            :always                             (parse-float)
             (and significant-digits is-output?) (gstring/format (str "%." significant-digits "f")))))
 
       (or (= v-kind :discrete) multi-discrete?)
       (let [{llist :variable/list}  (d/pull @@vms-conn '[{:variable/list [* {:list/options [*]}]}] (:db/id variable))
             {options :list/options} llist
             options                 (index-by :list-option/value options)]
-        (fn discrete-fmt [value]
+        (fn discrete-fmt [value & [{:keys [export?]}]]
           (if-let [option (get options value)]
-            (or @(<t (:list-option/result-translation-key option))
-                @(<t (:list-option/translation-key option)))
+            (if export?
+              (or @(<t (:list-option/export-translation-key option))
+                  @(<t (:list-option/result-translation-key option))
+                  @(<t (:list-option/translation-key option)))
+              (or @(<t (:list-option/result-translation-key option))
+                  @(<t (:list-option/translation-key option))))
             value)))
 
       (= v-kind :text)

--- a/projects/behave_cms/src/cljs/behave_cms/lists/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/lists/views.cljs
@@ -5,7 +5,8 @@
             [behave-cms.components.entity-form :refer [entity-form]]
             [behave-cms.events]
             [behave-cms.subs]
-            [behave-cms.components.translations :refer [all-translations]]))
+            [behave-cms.components.translations :refer [all-translations]]
+            [string-utils.interface             :refer [->kebab]]))
 
 (defn- lists-table []
   (let [lists     (rf/subscribe [:pull-with-attr :list/name '[* {:list/options [*]}]])
@@ -53,8 +54,9 @@
                    :id           (:db/id @*list-option)
                    :on-create    #(-> %
                                       (assoc :list-option/order (count @list-options))
-                                      (assoc :list-option/translation-key (str "behaveplus:list-option:" (:list/name llist) ":" (:list-option/name %)))
-                                      (assoc :list-option/result-translation-key (str "behaveplus:list-option:result:" (:list/name llist) ":" (:list-option/name %))))
+                                      (assoc :list-option/translation-key (->kebab (str "behaveplus:list-option:" (:list/name llist) ":" (:list-option/name %))))
+                                      (assoc :list-option/result-translation-key (->kebab (str "behaveplus:list-option:result:" (:list/name llist) ":" (:list-option/name %))))
+                                      (assoc :list-option/export-translation-key (->kebab (str "behaveplus:list-option:export:" (:list/name llist) ":" (:list-option/name %)))))
                    :fields       [{:label     "Name"
                                    :required? true
                                    :field-key :list-option/name}
@@ -83,7 +85,9 @@
      [:h4 "Worksheet Translation"]
      [all-translations (:list-option/translation-key @*list-option)]
      [:h4 "Result Translation"]
-     [all-translations (:list-option/result-translation-key @*list-option)]]))
+     [all-translations (:list-option/result-translation-key @*list-option)]
+     [:h4 "Export Translation"]
+     [all-translations (:list-option/export-translation-key @*list-option)]]))
 
 (defn- list-form [llist]
   (let [tag-sets        (rf/subscribe [:pull-with-attr :tag-set/name])


### PR DESCRIPTION
-------

## Purpose
- Adds export translation key to VMS
- Updates formatters to support new translation key
- Includes migration to update translation key for Moisture Scenarios

## Related Issues
Closes BHP1-1285

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Start the VMS, run the following migrations:
 - `migrations.2025-06-25-add-moisture-scenario-export-translations`
2. Visit the Lists tab
3. Verify that `MoistureScenarios` have Export Translation Keys that
   are only their short code (e.g. `D1L1`)
3. Sync with the App
4. Run the attached Worksheet
6. Verify that Result output uses the entire name of the Moisture Scenarios (not shortened)
5. Download the CSV Export
6. Verify that CSV output only includes the shortcode of the Moisture Scenarios