### PR TITLE
[BHP1-1325] Update VMS, App to use `:pivot-column/order`

### DIFF
--- a/bases/behave_schema/src/behave/schema/pivot_table.cljc
+++ b/bases/behave_schema/src/behave/schema/pivot_table.cljc
@@ -9,18 +9,23 @@
 
 ;;; Spec
 
-(s/def :pivot-table/columns  many-ref?)
-(s/def :pivot-column/function  keyword?)
-(s/def :pivot-column/group-variable-uuid  uuid-string?)
-(s/def :pivot-column/function  valid-pivot-value-fn?)
+(s/def :pivot-table/columns              many-ref?)
+(s/def :pivot-column/type                valid-pivot-column-type?)
+(s/def :pivot-column/group-variable-uuid uuid-string?)
+(s/def :pivot-column/order               int?)
+(s/def :pivot-column/function            valid-pivot-value-fn?)
 
 (s/def :behave/pivot-table (s/keys :req [:pivot-table/title
                                          :pivot-table/columns]))
 
-(s/def :behave/pivot-table-column-field (s/keys :req [:pivot-column/group-variable-uuid]))
+(s/def :behave/pivot-table-column-field (s/keys :req [:pivot-column/group-variable-uuid
+                                                      :pivot-column/type]
+                                                :opt [:pivot-column/order]))
 
 (s/def :behave/pivot-table-column-value (s/keys :req [:pivot-column/group-variable-uuid
-                                                      :pivot-column/function]))
+                                                      :pivot-column/type
+                                                      :pivot-column/function]
+                                                :opt [:pivot-column/order]))
 
 ;;; Schema
 (def
@@ -46,7 +51,7 @@
 
    {:db/ident       :pivot-column/order
     :db/doc         "Pivot Column's order"
-    :db/valueType   :db.type/string
+    :db/valueType   :db.type/long
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :pivot-column/group-variable-uuid
@@ -65,8 +70,10 @@
              :pivot-table/columns #{1 2 3}})
 
   (s/valid? :behave/pivot-table-column-field
-            {:pivot-column/group-variable-uuid (str (random-uuid))})
+            {:pivot-column/group-variable-uuid (str (random-uuid))
+             :pivot-column/type                :field})
 
   (s/valid? :behave/pivot-table-column-value
             {:pivot-column/group-variable-uuid (str (random-uuid))
+             :pivot-column/type                :value
              :pivot-column/function            :sum}))

--- a/components/schema_migrate/src/schema_migrate/interface.clj
+++ b/components/schema_migrate/src/schema_migrate/interface.clj
@@ -82,7 +82,7 @@
                   the same transaction where you've manually assigned :db/id)."}
   build-translations-payload c/build-translations-payload)
 
-(def ^{:arglists '([conn eid-start t-key->translation-map])
+(def ^{:arglists '([conn shortcode t-key->translation-map])
        :doc      "Creates a payload to update existing translations for specific language shortcode."}
   update-translations-payload c/update-translations-payload)
 

--- a/development/migrations/2025_05_02_remove_duplicate_output_variable_translation.clj
+++ b/development/migrations/2025_05_02_remove_duplicate_output_variable_translation.clj
@@ -1,0 +1,50 @@
+(ns migrations.2025-05-02-remove-duplicate-output-variable-translation
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; Remove duplicate "behaveplus:output_variable" translation key
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def duplicate-translation-eid
+  (d/q '[:find ?e .
+         :where
+         [?e :translation/key "behaveplus:output_variable"]
+         [?e :translation/translation "output variable"]]
+       (d/db conn)))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload [[:db/retractEntity duplicate-translation-eid]])
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (try (def tx-data @(d/transact conn payload))
+       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/development/migrations/2025_06_30_update_mortality_pivot_table.clj
+++ b/development/migrations/2025_06_30_update_mortality_pivot_table.clj
@@ -1,0 +1,116 @@
+(ns migrations.2025-06-30-update-mortality-pivot-table
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave.schema.pivot-table :refer [schema]]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; 1. Re-creates :pivot-column/order as type `long`
+;; 2. Renames the Pivot Table to "Equation Type"
+;; 3. Rename "CVSorCLS" to "CVS or CLS"
+;; 4. Change the column order to: Mortality Tree Species, Equation Type, and “CVS or CLS” (with spaces)
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+(defn find-eid
+  "Finds an entity ID using the attribute (`a`) and
+   value (`v`) specified."
+  [conn a v]
+  (d/q '[:find ?e .
+         :in $ ?a ?v
+         :where [?e ?a ?v]]
+       (d/db conn) a v))
+
+(defn find-eid-by
+  "Finds an entity ID using `attr` from map `m`."
+  [conn attr m]
+  {:pre [(map? m)]}
+  (find-eid conn attr (get m attr)))
+
+;;; Re-create :pivot-column/order as `long`
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def pivot-column-order-attr-eid (find-eid conn :db/ident :pivot-column/order))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def pivot-table-eid
+  (find-eid conn :pivot-table/title "CVSorCLS"))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def cvs-or-cls-variable-eid
+  (find-eid conn :variable/name "CVSorCLS"))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def cvs-or-cls-group-variable
+  (sm/t-key->uuid conn "behaveplus:mortality:output:tree_mortality:tree_mortality:cvsorcls"))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def re-create-pivot-column-order-payload 
+  (concat [[:db/retract pivot-column-order-attr-eid :db/ident]
+           [:db/retract pivot-column-order-attr-eid :db/doc]]
+          (filter #(= :pivot-column/order (:db/ident %)) schema)))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def update-pivot-table-payload
+  {:db/id             pivot-table-eid  
+   :pivot-table/title "Equation Type"})
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def update-cvs-or-cls-variable-payload
+  {:db/id              cvs-or-cls-variable-eid
+   :variable/name      "CVS or CLS"
+   :variable/bp6-code  "vCVSorCLS"
+   :variable/bp6-label "CVS or CLS"})
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def update-cvs-or-cls-translation-payload
+  (sm/update-translations-payload
+   conn
+   "en-US"
+   {"behaveplus:mortality:output:tree_mortality:tree_mortality:cvsorcls" "CSV or CLS"}))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def pivot-column-order-payload
+  (->> [{:pivot-column/group-variable-uuid (sm/t-key->uuid conn "behaveplus:mortality:input:fuelvegetation_overstory:mortality_tree_species:mortality_tree_species")
+         :pivot-column/order               0}
+        {:pivot-column/group-variable-uuid (sm/t-key->uuid conn "behaveplus:mortality:output:tree_mortality:tree_mortality:mortality-equation")
+         :pivot-column/order               1}
+        {:pivot-column/group-variable-uuid (sm/t-key->uuid conn "behaveplus:mortality:output:tree_mortality:tree_mortality:cvsorcls")
+         :pivot-column/order               2}]
+       (mapv #(assoc % :db/id (find-eid-by conn :pivot-column/group-variable-uuid %)))))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload (concat re-create-pivot-column-order-payload 
+                     [update-pivot-table-payload update-cvs-or-cls-variable-payload]
+                     update-cvs-or-cls-translation-payload
+                     pivot-column-order-payload))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (try (def tx-data @(d/transact conn payload))
+       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))
+

--- a/development/migrations/2025_06_30_update_mortality_pivot_table.clj
+++ b/development/migrations/2025_06_30_update_mortality_pivot_table.clj
@@ -93,8 +93,7 @@
        (mapv #(assoc % :db/id (find-eid-by conn :pivot-column/group-variable-uuid %)))))
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(def payload (concat re-create-pivot-column-order-payload 
-                     [update-pivot-table-payload update-cvs-or-cls-variable-payload]
+(def payload (concat [update-pivot-table-payload update-cvs-or-cls-variable-payload]
                      update-cvs-or-cls-translation-payload
                      pivot-column-order-payload))
 
@@ -104,7 +103,9 @@
 
 (comment
   #_{:clj-kondo/ignore [:missing-docstring]}
-  (try (def tx-data @(d/transact conn payload))
+  (try
+    (def tx-data-1 @(d/transact conn re-create-pivot-column-order-payload))
+    (def tx-data-2 @(d/transact conn payload))
        (catch Exception e  (str "caught exception: " (.getMessage e)))))
 
 ;; ===========================================================================================================
@@ -112,5 +113,7 @@
 ;; ===========================================================================================================
 
 (comment
-  (sm/rollback-tx! conn @tx-data))
+  (do
+    (sm/rollback-tx! conn @tx-data-1)
+    (sm/rollback-tx! conn @tx-data-2)))
 

--- a/development/migrations/2025_06_30_update_mortality_pivot_table.clj
+++ b/development/migrations/2025_06_30_update_mortality_pivot_table.clj
@@ -58,10 +58,14 @@
 ;; ===========================================================================================================
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(def re-create-pivot-column-order-payload 
-  (concat [[:db/retract pivot-column-order-attr-eid :db/ident]
-           [:db/retract pivot-column-order-attr-eid :db/doc]]
-          (filter #(= :pivot-column/order (:db/ident %)) schema)))
+(def deprecate-old-pivot-column-order-payload
+  [{:db/id    pivot-column-order-attr-eid
+    :db/ident :pivot-table/deprecated-order-type-string
+    :db/doc   "Depreacted Pivot Column's order (type string)"}])
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def add-new-pivot-column-order-payload
+  (filter #(= :pivot-column/order (:db/ident %)) schema))
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (def update-pivot-table-payload
@@ -104,9 +108,10 @@
 (comment
   #_{:clj-kondo/ignore [:missing-docstring]}
   (try
-    (def tx-data-1 @(d/transact conn re-create-pivot-column-order-payload))
-    (def tx-data-2 @(d/transact conn payload))
-       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+    (def tx-data-1 @(d/transact conn deprecate-old-pivot-column-order-payload))
+    (def tx-data-2 @(d/transact conn add-new-pivot-column-order-payload))
+    (def tx-data-3 @(d/transact conn payload))
+    (catch Exception e  (str "caught exception: " (.getMessage e)))))
 
 ;; ===========================================================================================================
 ;; In case we need to rollback.

--- a/projects/behave_cms/src/cljs/behave_cms/components/common.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/components/common.cljs
@@ -264,10 +264,10 @@
   - `opt-fns` - An optional hash-map of functions
 
   `opt-fns` can contain the following K/V pairs:
-  - `:on-select`   - Fn callled a table row is selected.
-  - `:on-delete`   - Fn callled a table row is deleted.
-  - `:on-decrease` - Fn callled a table row position is increased.
-  - `:on-decrease` - Fn callled a table row position is decreased."
+  - `:on-select`   - Fn called a table row is selected.
+  - `:on-delete`   - Fn called a table row is deleted.
+  - `:on-increase` - Fn called a table row position is increased.
+  - `:on-decrease` - Fn called a table row position is decreased."
   [columns rows & [{:keys [on-select on-delete on-increase on-decrease caption add-group-variable-fn]}]]
   [:div
    {:style {:width      "100%"

--- a/projects/behave_cms/src/cljs/behave_cms/submodules/subs.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/submodules/subs.cljs
@@ -39,9 +39,11 @@
                  [?v :variable/name ?name]]
                [pivot-table-id]]))
  (fn [results]
-   (mapv (fn [[id name]]
-           (-> @(subscribe [:entity id])
-               (assoc :variable/name name))) results)))
+   (->> results
+        (mapv (fn [[eid v-name]]
+                (-> @(subscribe [:entity eid])
+                    (assoc :variable/name v-name))))
+        (sort-by :pivot-column/order))))
 
 (reg-sub
  :pivot-table/values

--- a/projects/behave_cms/src/cljs/behave_cms/submodules/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/submodules/views.cljs
@@ -78,9 +78,11 @@
                      [simple-table
                       [:variable/name]
                       pivot-table-fields
-                      {:caption   "Pivot Table Fields"
-                       :on-delete #(rf/dispatch [:api/delete-entity (:db/id %)])
-                       :on-select #(reset! pivot-column-id-atom (:db/id %))}]
+                      {:caption     "Pivot Table Fields"
+                       :on-increase #(rf/dispatch [:api/reorder % pivot-table-fields :pivot-column/order :inc])
+                       :on-decrease #(rf/dispatch [:api/reorder % pivot-table-fields :pivot-column/order :dec])
+                       :on-delete   #(rf/dispatch [:api/delete-entity (:db/id %)])
+                       :on-select   #(reset! pivot-column-id-atom (:db/id %))}]
                      [simple-table
                       [:variable/name :pivot-column/function]
                       pivot-table-values


### PR DESCRIPTION
-------

## Purpose
Use `:pivot-table/order` for determining the order of columns in the
Pivot Table

## Related Issues
Closes BHP1-1325

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Start VMS, run `migrations.2025-06-30-update-mortality-pivot-table`
2. Sync App, run Surface + Mortality with at least 3 Mortality
   Species, go to outputs
3. Verify that the order of columns is:
   - Mortality Tree Species
   - Equation Type
   - CVS or CLS
4. Verify that the title of the Pivot Table is "Equation Type"

## Screenshots