### PR TITLE
[BHP1-1325] Remove duplicate "behaveplus:output_variable" translation

### DIFF
--- a/development/migrations/2025_05_02_remove_duplicate_output_variable_translation.clj
+++ b/development/migrations/2025_05_02_remove_duplicate_output_variable_translation.clj
@@ -1,0 +1,50 @@
+(ns migrations.2025-05-02-remove-duplicate-output-variable-translation
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; Remove duplicate "behaveplus:output_variable" translation key
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def duplicate-translation-eid
+  (d/q '[:find ?e .
+         :where
+         [?e :translation/key "behaveplus:output_variable"]
+         [?e :translation/translation "output variable"]]
+       (d/db conn)))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload [[:db/retractEntity duplicate-translation-eid]])
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (try (def tx-data @(d/transact conn payload))
+       (catch Exception e  (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))


### PR DESCRIPTION
-------

## Purpose
EOM

## Related Issues
Closes BHP1-1325

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Start VMS, run migration `migrations.2025-05-02-remove-duplicate-output-variable-translation`
2. Run App, sync 
3. Run Surface + Mortality, only using single entries (no multi-valued/ranged
   inputs)
4. Verify output matrix has "Output Variable" capitalized

## Screenshots