### PR TITLE
[BHP1-1352] Auto Scroll Top in Standard View

### DIFF
--- a/projects/behave/src/cljs/behave/wizard/events.cljs
+++ b/projects/behave/src/cljs/behave/wizard/events.cljs
@@ -1,6 +1,7 @@
 (ns behave.wizard.events
   (:require [behave-routing.main           :refer [routes current-route-order]]
             [behave.lib.units              :refer [convert]]
+            [browser-utils.core :refer [scroll-top!]]
             [behave.solver.core            :refer [solve-worksheet]]
             [behave.vms.store              :as vms]
             [behave.store                  :as s]
@@ -351,3 +352,12 @@
  (fn [_ [_ workflow]]
    {:fx [[:dispatch [:local-storage/update-in [:state :*workflow] workflow]]
          [:dispatch [:state/set :*new-or-import workflow]]]}))
+
+(rf/reg-event-fx
+ :wizard/standard-navigate-io-tab
+ (fn [_ [_ ws-uuid io]]
+   {:fx [[:dispatch [:navigate (path-for routes :ws/wizard-standard
+                                         {:ws-uuid  ws-uuid
+                                          :workflow :standard
+                                          :io       io})]]]
+    :browser/scroll-top {}}))

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -804,15 +804,7 @@
          [:div.wizard-page
           [:div.wizard-header
            [io-tabs params #(when (not= io (:tab %))
-                              (if (= (:tab %) :input)
-                                (dispatch [:navigate (path-for routes :ws/wizard-standard
-                                                               {:ws-uuid  ws-uuid
-                                                                :workflow :standard
-                                                                :io       :input})])
-                                (dispatch [:navigate (path-for routes :ws/wizard-standard
-                                                               {:ws-uuid  ws-uuid
-                                                                :workflow :standard
-                                                                :io       :output})])))]
+                              (dispatch [:wizard/standard-navigate-io-tab ws-uuid (:tab %)]))]
            [:div.wizard-header__banner
             [:div.wizard-header__banner__icon
              [c/icon :modules]]
@@ -821,18 +813,6 @@
                @(<t (bp "module_output_selections"))
                @(<t (bp "module_input_selections")))]
             (show-or-close-notes-button @*show-notes?)]
-           [:div.wizard-header__submodule-navigator
-            [:div.wizard-header__submodule-navigator__label
-             (if (= (count modules) 1)
-               (gstring/format "%s %s" (:module/name (first modules)) (str (str/capitalize (name io)) "s"))
-               (apply gstring/format "%s & %s %s" (conj (mapv :module/name modules) (str (str/capitalize (name io)) "s"))))]
-            (let [->option (fn [[module-name {submodule-name :submodule/name}]]
-                             {:value submodule-name
-                              :label (str module-name " - " submodule-name)})]
-              [c/dropdown
-               {:on-change #(rf/dispatch [:wizard/scroll-into-view "wizard-review" (input-value %)])
-                :options   (map ->option all-submodules)}])]]
-          [:div.wizard-review
            (when @*show-notes?
              [:<>
               [:div.wizard-add-notes
@@ -853,37 +833,48 @@
                                                          (name io)
                                                          %])}])]
               [wizard-notes @*notes]])
+           [:div.wizard-header__submodule-navigator
+            [:div.wizard-header__submodule-navigator__label
+             (if (= (count modules) 1)
+               (gstring/format "%s %s" (:module/name (first modules)) (str (str/capitalize (name io)) "s"))
+               (apply gstring/format "%s & %s %s" (conj (mapv :module/name modules) (str (str/capitalize (name io)) "s"))))]
+            (let [->option (fn [[module-name {submodule-name :submodule/name}]]
+                             {:value submodule-name
+                              :label (str module-name " - " submodule-name)})]
+              [c/dropdown
+               {:on-change #(rf/dispatch [:wizard/scroll-into-view "wizard-page__body" (input-value %)])
+                :options   (map ->option all-submodules)}])]]
+          [:div.wizard-page__body
            (doall
             (for [module modules
                   :let   [module-name (:module/name module)]]
               [:div {:data-theme-color module-name}
-               [:div.wizard-review__submodules
-                (if (= io :input)
-                  (let [submodules (subscribe [:wizard/submodules-io-input-only (:db/id module)])]
-                    (doall
-                     (for [submodule @submodules
-                           :let      [{id :db/id
-                                       op :submodule/conditionals-operator} submodule]
-                           :when     @(subscribe [:wizard/show-submodule? ws-uuid id op])]
-                       ^{:key (:submodule/name submodule)}
-                       [:div.wizard-review__submodules__submodule
-                        {:id (:submodule/name submodule)}
-                        [:div.wizard-standard__submodule-header
-                         (:submodule/name submodule)]
-                        [build-groups params (:submodule/groups submodule) input-group]])))
-                  ;; io is :output
-                  (doall
-                   (let [submodules (subscribe [:wizard/submodules-io-output-only (:db/id module)])]
-                     (for [submodule @submodules
-                           :let      [{id :db/id
-                                       op :submodule/conditionals-operator} submodule]
-                           :when     @(subscribe [:wizard/show-submodule? ws-uuid id op])]
-                       ^{:key (:submodule/name submodule)}
-                       [:div.wizard-review__submodules__submodule
-                        {:id (:submodule/name submodule)}
-                        [:div.wizard-standard__submodule-header
-                         (:submodule/name submodule)]
-                        [build-groups params (:submodule/groups submodule) output-group]]))))]]))]
+               (if (= io :input)
+                 (let [submodules (subscribe [:wizard/submodules-io-input-only (:db/id module)])]
+                   (doall
+                    (for [submodule @submodules
+                          :let      [{id :db/id
+                                      op :submodule/conditionals-operator} submodule]
+                          :when     @(subscribe [:wizard/show-submodule? ws-uuid id op])]
+                      ^{:key (:submodule/name submodule)}
+                      [:div
+                       {:id (:submodule/name submodule)}
+                       [:div.wizard-standard__submodule-header
+                        (:submodule/name submodule)]
+                       [build-groups params (:submodule/groups submodule) input-group]])))
+                 ;; io is :output
+                 (doall
+                  (let [submodules (subscribe [:wizard/submodules-io-output-only (:db/id module)])]
+                    (for [submodule @submodules
+                          :let      [{id :db/id
+                                      op :submodule/conditionals-operator} submodule]
+                          :when     @(subscribe [:wizard/show-submodule? ws-uuid id op])]
+                      ^{:key (:submodule/name submodule)}
+                      [:div
+                       {:id (:submodule/name submodule)}
+                       [:div.wizard-standard__submodule-header
+                        (:submodule/name submodule)]
+                       [build-groups params (:submodule/groups submodule) output-group]]))))]))]
           (when (true? @*warn-limit?)
             [:div.wizard-warning
              (gstring/format  @(<t (bp "warn_input_limit")) @*multi-value-input-count @*multi-value-input-limit)])


### PR DESCRIPTION
-------

## Purpose

- Auto scrolls wizard to top when navigating to inputs/outputs page
- Move Notes to the header to avoid having to scroll up

## Related Issues
Closes BHP1-1352

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
#### Testing Auto scroll

1. Create a worksheet in standard view
2. Navigate to outputs page
3. Scroll down
4. Navigate to inputs page via either tabs or the progress bar and ensure in the inputs page you are scrolled to the top.
5. Scroll down in the inputs page and do the same for navigating to outputs page.

#### Testing Notes

1. Ensure the notes show at the top of the header without the need to scroll up.

## Screenshots