### PR TITLE
[BHP1-1336] Remove Vms Sync Button Component Completely

### DIFF
--- a/projects/behave/src/cljs/behave/components/toolbar.cljs
+++ b/projects/behave/src/cljs/behave/components/toolbar.cljs
@@ -225,31 +225,31 @@
 #_{:clj-kondo/ignore [:missing-docstring]}
 (defn toolbar [{:keys [ws-uuid] :as params}]
   (let [*loaded? (rf/subscribe [:app/loaded?])
-        tools    [{:icon     :home
-                   :label    @(<t (bp "home"))
-                   :on-click #(rf/dispatch [:wizard/navigate-home])}
-                  {:icon     :save
-                   :label    @(<t (bp "save"))
-                   :on-click #(when ws-uuid
-                                (let [worksheet-name @(rf/subscribe [:worksheet/name ws-uuid])]
-                                  (rf/dispatch [:wizard/save
-                                                ws-uuid
-                                                (gstring/format "behave7-%s.bp7"
-                                                                (or worksheet-name ws-uuid))])))}
-                  {:icon     :print
-                   :label    @(<t (bp "print"))
-                   :on-click (when ws-uuid
-                               #(rf/dispatch [:toolbar/print ws-uuid]))}
-                  (when-not (:jar-local? params)
-                    {:icon     :share
-                     :label    @(<t (bp "vms_sync"))
-                     :on-click #(rf/dispatch [:dev/export-from-vms])})
-                  #_{:icon     :zoom-in
-                     :label    (bp "zoom-in")
-                     :on-click on-click}
-                  #_{:icon     :zoom-out
-                     :label    (bp "zoom-out")
-                     :on-click on-click}]]
+        tools    (cond-> [{:icon     :home
+                           :label    @(<t (bp "home"))
+                           :on-click #(rf/dispatch [:wizard/navigate-home])}
+                          {:icon     :save
+                           :label    @(<t (bp "save"))
+                           :on-click #(when ws-uuid
+                                        (let [worksheet-name @(rf/subscribe [:worksheet/name ws-uuid])]
+                                          (rf/dispatch [:wizard/save
+                                                        ws-uuid
+                                                        (gstring/format "behave7-%s.bp7"
+                                                                        (or worksheet-name ws-uuid))])))}
+                          {:icon     :print
+                           :label    @(<t (bp "print"))
+                           :on-click (when ws-uuid
+                                       #(rf/dispatch [:toolbar/print ws-uuid]))}
+                          #_{:icon     :zoom-in
+                             :label    (bp "zoom-in")
+                             :on-click on-click}
+                          #_{:icon     :zoom-out
+                             :label    (bp "zoom-out")
+                             :on-click on-click}]
+                   (not (:jar-local? params))
+                   (conj {:icon     :share
+                          :label    @(<t (bp "vms_sync"))
+                          :on-click #(rf/dispatch [:dev/export-from-vms])}))]
     [:div.toolbar
      [:div.toolbar__tools
       (for [tool tools]


### PR DESCRIPTION
-------

## Purpose

VMS Button component still showing (with no label/icon) when specified in the config. This should completely remove the component.


## Related Issues
Closes BHP1-1336

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Update config with `{:client {:jar-local? true}}`
2. Open local app and ensure there is no button component after the print icon

## Screenshots