### PR TITLE
[BHP1-1303] Avoid Page Breaks in PDF for sections

### DIFF
--- a/projects/behave/resources/public/css/app-style.css
+++ b/projects/behave/resources/public/css/app-style.css
@@ -1410,6 +1410,14 @@ body {
     overflow-y: visible;
   }
 
+  .print__inputs-table,
+  .print__result-table,
+  .wizard-print__results,
+  .wizard-results__graphs,
+  .wizard-results__graph {
+    break-inside: avoid;
+  }
+
 }
 
 /* -- End Print View -- */

--- a/projects/behave/src/cljs/behave/components/results/graphs.cljs
+++ b/projects/behave/src/cljs/behave/components/results/graphs.cljs
@@ -34,7 +34,7 @@
                                               (first))
                             y-min (:y-axis-limit/min y-axis-limit)
                             y-max (:y-axis-limit/max y-axis-limit)]]
-           [:<>
+           [:div.wizard-results__graph
             [:div.wizard-graph__output-header
              @(subscribe [:wizard/gv-uuid->resolve-result-variable-name output-uuid])]
             [:div.wizard-results__graph

--- a/projects/behave/src/cljs/behave/print/views.cljs
+++ b/projects/behave/src/cljs/behave/print/views.cljs
@@ -39,11 +39,12 @@
      [:div.wizard-print__header "Inputs"]
      [inputs-table ws-uuid]
      [wizard-notes notes]
-     [:div.wizard-print__header "Results"]
-     [search-tables ws-uuid]
-     [pivot-tables ws-uuid]
-     (if directional-tables?
-       [directional-result-tables ws-uuid]
-       [result-matrices ws-uuid])
-     [result-graphs ws-uuid graph-data]
-     [result-diagrams ws-uuid]]))
+     [:div.wizard-print__results
+      [:div.wizard-print__header "Results"]
+      [search-tables ws-uuid]
+      [pivot-tables ws-uuid]
+      (if directional-tables?
+        [directional-result-tables ws-uuid]
+        [result-matrices ws-uuid])
+      [result-graphs ws-uuid graph-data]
+      [result-diagrams ws-uuid]]]))


### PR DESCRIPTION
-------

## Purpose

1. Avoid page break on sections of the pdf

## Related Issues
Closes BHP1-1303

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open this worksheet:
2. Ensure these sections avoid page break:

- Inputs
- Results
- Graphs

3. Ensure Graph headers and graph also avoid page breaks

## Screenshots