### PR TITLE
[BHP1-1361] Fix Celsius to Fahrenheit Conversion

### DIFF
--- a/development/migrations/2025_07_16_add_min_max_air_temperature_variable.clj
+++ b/development/migrations/2025_07_16_add_min_max_air_temperature_variable.clj
@@ -1,4 +1,4 @@
-(ns migrations.template
+(ns migrations.2025-07-16-add-min-max-air-temperature-variable
   (:require [schema-migrate.interface :as sm]
             [datomic.api :as d]
             [behave-cms.store :refer [default-conn]]
@@ -22,7 +22,9 @@
 ;; ===========================================================================================================
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(def payload [])
+(def payload [{:db/id (sm/name->eid conn :variable/name "Air Temperature")
+               :variable/minimum -40.0
+               :variable/maximum 120.0}])
 
 ;; ===========================================================================================================
 ;; Transact Payload

--- a/development/migrations/template.clj
+++ b/development/migrations/template.clj
@@ -22,7 +22,9 @@
 ;; ===========================================================================================================
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(def payload [])
+(def payload [{:db/id (sm/name->eid conn :variable/name "Air Temperature")
+               :variable/minimum -40.0
+               :variable/maximum 120.0}])
 
 ;; ===========================================================================================================
 ;; Transact Payload

--- a/projects/behave/src/cljs/behave/lib/units.cljs
+++ b/projects/behave/src/cljs/behave/lib/units.cljs
@@ -66,7 +66,7 @@
    {:short "mi"          :system "english" :enum enum/length-units                  :dimension :length                  :unit "Miles"}
    {:short "mi/h"        :system "english" :enum enum/speed-units                   :dimension :speed                   :unit "MilesPerHour"}
    {:short "ms"} ; FIXME
-   {:short "oF"          :system "english" :enum enum/temperature-units             :dimension :temperature-units       :unit "Fahrenheit"}
+   {:short "oF"          :system "english" :enum enum/temperature-units             :dimension :temperature             :unit "Fahrenheit"}
    {:short "per ac"} ; FIXME Tree Count
    {:short "ton/ac"      :system "english" :enum enum/loading-units                 :dimension :loading-units           :unit "TonnesPerAcre"}
    {:short "psi"         :system "english" :enum enum/pressure-units                :dimension :pressure-units          :unit "PoundPerSquareInch"}])


### PR DESCRIPTION
## Purpose

1. Fixes app from crashing when units are changed from Fahrenheit to Celsius
2. Add min and max values to temperature input

## Related Issues
Closes BHP1-1361

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open local VMS and run migration script in ns `migrations.2025-07-16-add-min-max-air-temperature-variable`
2. Open local app and sync vms
3. Create a surface worksheet and select output "probability of Ignition"
4. Navigate to Inputs > Weather
5. Ensure "Air Temperature" output has min and max value as placeholders
6. Change units from F -> C. Ensure the app does not crash
7. Enter a value for "Air Temperature"
8. Change units. Ensure the value is properly converted.

## Screenshots