### PR TITLE
[BHP1-1356] Fix Solo running Torching Trees/Active Crown Spot Dist.

### DIFF
--- a/development/migrations/2025_07_25_spot_torching_trees_action.clj
+++ b/development/migrations/2025_07_25_spot_torching_trees_action.clj
@@ -1,0 +1,83 @@
+(ns migrations.2025-07-25-spot-torching-trees-action
+  (:require
+   [schema-migrate.interface :as sm]
+   [datomic.api              :as d]
+   [behave-cms.store         :refer [default-conn]]
+   [behave-cms.server        :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+;;
+;; Automatically selects "Torching" Fire Type when no other inputs are selected.
+;;
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Build Payload
+;; ===========================================================================================================
+
+;; Create conditional
+(defn ->equal-cond [t-key value]
+  (sm/->entity
+   {:conditional/group-variable-uuid (sm/t-key->uuid conn t-key)
+    :conditional/type                :group-variable
+    :conditional/operator            :equal
+    :conditional/values              value}))
+
+;; Variables
+(def active-crown "behaveplus:crown:output:spotting_active_crown_fire:maximum_spotting_distance:maximum_spotting_distance")
+(def torching-trees "behaveplus:crown:output:spotting_active_crown_fire:maximum_spotting_distance:max-spot-dist-from-torching-trees")
+
+(def crown (sm/t-key->entity conn "behaveplus:crown"))
+
+(def crown-output-submodule-variables
+  (->> (:module/submodules crown)
+       (filter #(= :output (:submodule/io %)))
+       (mapcat :submodule/groups)
+       (mapcat :group/group-variables)
+       (map :group-variable/translation-key)
+       (set)))
+
+(def torching-trees-payload
+  {:db/id (sm/t-key->eid conn "behaveplus:crown:input:spotting:linked_inputs:fire_type")
+   :group-variable/actions
+   [(sm/->entity {:action/name                  "Select 'Torching' Fire Type when 'Form Torching Trees' is selected and no other Crown outputs are selected."
+                  :action/type                  :select
+                  :action/target-value          "1"
+                  :action/conditionals-operator :and
+                  :action/conditionals
+                  (concat [(->equal-cond torching-trees "true")]
+                          (map #(->equal-cond % "false") (disj crown-output-submodule-variables torching-trees)))})]})
+
+(def active-crown-payload
+  {:db/id (sm/t-key->eid conn "behaveplus:crown:input:spotting:linked_inputs:fire_type")
+   :group-variable/actions
+   [(sm/->entity {:action/name                  "Select 'Crowning' Fire Type when 'From Active Crown Fire' is selected and no other Crown outputs are selected."
+                  :action/type                  :select
+                  :action/target-value          "3"
+                  :action/conditionals-operator :and
+                  :action/conditionals
+                  (concat [(->equal-cond active-crown "true")]
+                          (map #(->equal-cond % "false") (disj crown-output-submodule-variables active-crown)))})]})
+
+(def payload [torching-trees-payload active-crown-payload])
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  (def tx-data (d/transact conn payload)))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/development/migrations/2025_07_25_spot_torching_trees_action.clj
+++ b/development/migrations/2025_07_25_spot_torching_trees_action.clj
@@ -44,29 +44,27 @@
        (map :group-variable/translation-key)
        (set)))
 
-(def torching-trees-payload
+(def payload
   {:db/id (sm/t-key->eid conn "behaveplus:crown:input:spotting:linked_inputs:fire_type")
+   :group-variable/conditionally-set? true
    :group-variable/actions
-   [(sm/->entity {:action/name                  "Select 'Torching' Fire Type when 'Form Torching Trees' is selected and no other Crown outputs are selected."
+   [;; Torching
+    (sm/->entity {:action/name                  "Select 'Torching' Fire Type when 'Form Torching Trees' is selected and no other Crown outputs are selected."
                   :action/type                  :select
                   :action/target-value          "1"
                   :action/conditionals-operator :and
                   :action/conditionals
                   (concat [(->equal-cond torching-trees "true")]
-                          (map #(->equal-cond % "false") (disj crown-output-submodule-variables torching-trees)))})]})
+                          (map #(->equal-cond % "false") (disj crown-output-submodule-variables torching-trees)))})
 
-(def active-crown-payload
-  {:db/id (sm/t-key->eid conn "behaveplus:crown:input:spotting:linked_inputs:fire_type")
-   :group-variable/actions
-   [(sm/->entity {:action/name                  "Select 'Crowning' Fire Type when 'From Active Crown Fire' is selected and no other Crown outputs are selected."
+    ;; Crowning
+    (sm/->entity {:action/name                  "Select 'Crowning' Fire Type when 'From Active Crown Fire' is selected and no other Crown outputs are selected."
                   :action/type                  :select
                   :action/target-value          "3"
                   :action/conditionals-operator :and
                   :action/conditionals
                   (concat [(->equal-cond active-crown "true")]
                           (map #(->equal-cond % "false") (disj crown-output-submodule-variables active-crown)))})]})
-
-(def payload [torching-trees-payload active-crown-payload])
 
 ;; ===========================================================================================================
 ;; Transact Payload

--- a/projects/behave/src/cljs/behave/solver/core.cljs
+++ b/projects/behave/src/cljs/behave/solver/core.cljs
@@ -156,8 +156,13 @@
        (if (prev-output-uuids src-uuid)
          (let [output     (get prev-outputs src-uuid)
                group-uuid (q/group-variable->group dst-uuid)]
-           (log-solver [:ADD-LINK [:SRC-UUID src-uuid :DST-UUID dst-uuid] [:OUTPUT output :GROUP-UUID group-uuid]])
-           (assoc-in acc [group-uuid 0 dst-uuid] output))
+
+           ;; [BHP1-1356] Only apply output link when the input is empty
+           (if (nil? (get-in acc [group-uuid 0 dst-uuid]))
+             (do
+               (log-solver [:ADD-LINK [:SRC-UUID src-uuid] [:GROUP-UUID group-uuid :DST-UUID dst-uuid :OUTPUT output]])
+               (assoc-in acc [group-uuid 0 dst-uuid] output))
+             acc))
          acc))
      inputs
      destination-links)))


### PR DESCRIPTION
## Purpose
Fixes issue where Torching Trees/Active Crown Fire would not be able
to be run solo (without Surface/Crown modules).

1. Adds migration `migrations.2025-07-25-spot-torching-trees-action`
2. Updates solver to not overwrite inputs. Fixes issue where
conditionally set inputs were being overwritten by Surface/Crown
module even though the module was not being run.

## Related Issues
Closes BHP1-1356

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Run migration `migrations.2025-07-25-spot-torching-trees-action`
2. Sync Dev, run the following worksheet:
3. Verify that the output for Max Spotting from Torching Trees is
   greater than 0