### PR TITLE
[BHP1-1338] Fix Missing Output Table

### DIFF
--- a/projects/behave/src/cljs/behave/wizard/subs.cljs
+++ b/projects/behave/src/cljs/behave/wizard/subs.cljs
@@ -837,7 +837,7 @@
  :wizard/output-directional-tables?
  (fn [[_ ws-uuid]] (subscribe [:worksheet/output-directions ws-uuid]))
  (fn [output-directions]
-   (> (count output-directions) 1)))
+   (pos? (count output-directions))))
 
 (defn- group-variable-discrete?
   [gv-uuid]


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1338

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open this worksheet:  [Surface_NoTable_Range1h (1).zip](https://github.com/user-attachments/files/21606448/Surface_NoTable_Range1h.1.zip)

2. Ensure Output table is displayed

## Screenshots