### PR TITLE
[BHP1-1387] Fix Empty Result Table

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -234,17 +234,18 @@
                                             (remove #(contains? pivot-table-uuids %))
                                             (remove #(contains? directional-uuids %))
                                             (sort-by #(.indexOf gv-order %)))]
-    [:div.wizard-results
-     [construct-result-matrices
-     {:ws-uuid               ws-uuid
-      :process-map-units?    (fn [v-uuid]
-                               (and map-units-enabled?
-                                    (map-unit-convertible-variables v-uuid)))
-      :multi-valued-inputs   @(subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
-      :output-gv-uuids       output-gv-uuids
-      :output-entities       (map (fn [gv-uuid]
-                                    (-> @(subscribe [:wizard/group-variable gv-uuid])
-                                        (merge {:units (get units-lookup gv-uuid)}))) output-gv-uuids)
-      :units-lookup          units-lookup
-      :formatters            @(subscribe [:worksheet/result-table-formatters output-gv-uuids])
-      :table-setting-filters table-setting-filters}]]))
+    (when (seq output-gv-uuids)
+     [:div.wizard-results
+      [construct-result-matrices
+       {:ws-uuid               ws-uuid
+        :process-map-units?    (fn [v-uuid]
+                                 (and map-units-enabled?
+                                      (map-unit-convertible-variables v-uuid)))
+        :multi-valued-inputs   @(subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
+        :output-gv-uuids       output-gv-uuids
+        :output-entities       (map (fn [gv-uuid]
+                                      (-> @(subscribe [:wizard/group-variable gv-uuid])
+                                          (merge {:units (get units-lookup gv-uuid)}))) output-gv-uuids)
+        :units-lookup          units-lookup
+        :formatters            @(subscribe [:worksheet/result-table-formatters output-gv-uuids])
+        :table-setting-filters table-setting-filters}]])))


### PR DESCRIPTION
-------

## Purpose

- Show Result Matrices only when there are non directional outputs

## Related Issues
Closes BHP1-1387

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open this worksheet:
[SurfaceVectoring.zip](https://github.com/user-attachments/files/21778543/SurfaceVectoring.zip)

2. Ensure there is not result table with empty outputs

## Screenshots