### PR TITLE
[BHP1-1333] Hide Fireline Constructed Scatterplot when Not Contained

### DIFF
--- a/projects/behave/src/cljs/behave/solver/diagrams.cljs
+++ b/projects/behave/src/cljs/behave/solver/diagrams.cljs
@@ -27,7 +27,8 @@
      (contain/getFireBackAtReport module)
      (contain/getFireHeadAtReport module)
      (contain/getFireBackAtAttack module)
-     (contain/getFireHeadAtAttack module)]))
+     (contain/getFireHeadAtAttack module)
+     (contain/getContainmentStatus module)]))
 
 (defmethod build-event-vector :fire-shape
   [{:keys [ws-uuid row-id diagram module]}]

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -680,29 +680,31 @@
                     fire-back-at-report
                     fire-head-at-report
                     fire-back-at-attack
-                    fire-head-at-attack]]
-   {:transact [{:worksheet/_diagrams                   [:worksheet/uuid ws-uuid]
-                :worksheet.diagram/title               title
-                :worksheet.diagram/group-variable-uuid group-variable-uuid
-                :worksheet.diagram/row-id              row-id
-                :worksheet.diagram/ellipses            [(let [l (- fire-head-at-report fire-back-at-report)
-                                                              w (/ l length-to-width-ratio)]
-                                                          {:ellipse/legend-id       "FirePerimiterAtReport"
-                                                           :ellipse/semi-major-axis (/ l 2)
-                                                           :ellipse/semi-minor-axis (/ w 2)
-                                                           :ellipse/rotation        90
-                                                           :ellipse/color           "blue"})
-                                                        (let [l (- fire-head-at-attack fire-back-at-attack)
-                                                              w (/ l length-to-width-ratio)]
-                                                          {:ellipse/legend-id       "FirePerimiterAtAttack"
-                                                           :ellipse/semi-major-axis (/ l 2)
-                                                           :ellipse/semi-minor-axis (/ w 2)
-                                                           :ellipse/rotation        90
-                                                           :ellipse/color           "red"})]
-                :worksheet.diagram/scatter-plots       [{:scatter-plot/legend-id     "FireLineConstructed"
-                                                         :scatter-plot/color         "black"
-                                                         :scatter-plot/x-coordinates fire-perimeter-points-X
-                                                         :scatter-plot/y-coordinates fire-perimeter-points-Y}]}]}))
+                    fire-head-at-attack
+                    contain-status]]
+   {:transact [(cond-> {:worksheet/_diagrams                   [:worksheet/uuid ws-uuid]
+                        :worksheet.diagram/title               title
+                        :worksheet.diagram/group-variable-uuid group-variable-uuid
+                        :worksheet.diagram/row-id              row-id
+                        :worksheet.diagram/ellipses            [(let [l (- fire-head-at-report fire-back-at-report)
+                                                                      w (/ l length-to-width-ratio)]
+                                                                  {:ellipse/legend-id       "FirePerimiterAtReport"
+                                                                   :ellipse/semi-major-axis (/ l 2)
+                                                                   :ellipse/semi-minor-axis (/ w 2)
+                                                                   :ellipse/rotation        90
+                                                                   :ellipse/color           "blue"})
+                                                                (let [l (- fire-head-at-attack fire-back-at-attack)
+                                                                      w (/ l length-to-width-ratio)]
+                                                                  {:ellipse/legend-id       "FirePerimiterAtAttack"
+                                                                   :ellipse/semi-major-axis (/ l 2)
+                                                                   :ellipse/semi-minor-axis (/ w 2)
+                                                                   :ellipse/rotation        90
+                                                                   :ellipse/color           "red"})]}
+                 (= contain-status 3)
+                 (assoc :worksheet.diagram/scatter-plots       [{:scatter-plot/legend-id     "FireLineConstructed"
+                                                                 :scatter-plot/color         "black"
+                                                                 :scatter-plot/x-coordinates fire-perimeter-points-X
+                                                                 :scatter-plot/y-coordinates fire-perimeter-points-Y}]))]}))
 
 (rp/reg-event-fx
  :worksheet/add-surface-fire-shape-diagram


### PR DESCRIPTION
-------

## Purpose

- When the fire cannot be contained, the fireline Constructed Graph should be omitted from the resulting diagram.

## Related Issues
Closes BHP1-1333

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open and re-run this worksheet: 
[Contain_Fireline_Constructed.zip](https://github.com/user-attachments/files/22281691/Contain_Fireline_Constructed.zip)

2. Ensure that when the fire is not contained, the fireline constructed points are omitted


## Screenshots