### PR TITLE
[BHP1-1246] Add Global Units Settings for English and Metric

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -24,4 +24,3 @@ jobs:
            git add resources/version.edn
            git commit -m "update version"
            git push
-           bb deploy

--- a/bases/behave_schema/src/behave/schema/worksheet.cljc
+++ b/bases/behave_schema/src/behave/schema/worksheet.cljc
@@ -176,6 +176,11 @@
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :input/units
+    :db/doc         "Input's units uuid."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :input/units-uuid
     :db/doc         "Input's units."
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
@@ -201,6 +206,11 @@
    ;; Outputs
    {:db/ident       :output/group-variable-uuid
     :db/doc         "Output's reference to Variable's UUID."
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :output/units
+    :db/doc         "outputs's units uuid."
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 

--- a/bases/behave_schema/src/behave/schema/worksheet.cljc
+++ b/bases/behave_schema/src/behave/schema/worksheet.cljc
@@ -249,7 +249,7 @@
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :result-header/units
-    :db/doc         "Result header's units."
+    :db/doc         "Result header's units shortcode."
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 

--- a/bases/behave_schema/src/behave/schema/worksheet.cljc
+++ b/bases/behave_schema/src/behave/schema/worksheet.cljc
@@ -176,7 +176,7 @@
     :db/cardinality :db.cardinality/one}
 
    {:db/ident       :input/units
-    :db/doc         "Input's units uuid."
+    :db/doc         "Deprecated use `:input/units-uuid`"
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 
@@ -209,7 +209,7 @@
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}
 
-   {:db/ident       :output/units
+   {:db/ident       :output/units-uuid
     :db/doc         "outputs's units uuid."
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}

--- a/projects/behave/resources/public/css/app-style.css
+++ b/projects/behave/resources/public/css/app-style.css
@@ -1320,6 +1320,10 @@ body {
   width: 40px;
 }
 
+.settings__general-units__units-system-selection {
+  padding: 10px;
+}
+
 .settings__body {
   overflow-x: scroll;
   overflow-y: scroll;

--- a/projects/behave/src/cljs/behave/components/unit_selector.cljs
+++ b/projects/behave/src/cljs/behave/components/unit_selector.cljs
@@ -50,7 +50,12 @@
                native-unit       @(rf/subscribe [:vms/entity-from-uuid native-unit-uuid])
                english-unit      @(rf/subscribe [:vms/entity-from-uuid english-unit-uuid])
                metric-unit       @(rf/subscribe [:vms/entity-from-uuid metric-unit-uuid])
-               default-unit      (or @*cached-unit native-unit english-unit metric-unit) ;; FIXME: Get from Worksheet settings
+               units-system       @(rf/subscribe [:settings/units-system])
+               default-unit      (or @*cached-unit
+                                     (case units-system
+                                       :english english-unit
+                                       :metric  metric-unit
+                                       native-unit))
                show-selector? (r/atom false)
                on-click       #(do
                                  (on-change-units %)
@@ -58,7 +63,6 @@
                pre-selected-unit (or (get units-by-uuid *unit-uuid) default-unit)]
     [:div.wizard-input__units
      (if (or (>= 1 (count units)) (nil? @dimension))
-      [:div.wizard-input__units__text
-       (str @(<t (bp "units_used")) " " (:unit/short-code pre-selected-unit))]
-      [unit-selector (:bp/uuid pre-selected-unit) units on-click])]))
-
+       [:div.wizard-input__units__text
+        (str @(<t (bp "units_used")) " " (:unit/short-code pre-selected-unit))]
+       [unit-selector (:bp/uuid pre-selected-unit) units on-click])]))

--- a/projects/behave/src/cljs/behave/settings/events.cljs
+++ b/projects/behave/src/cljs/behave/settings/events.cljs
@@ -33,12 +33,17 @@
  (fn [{units-settings :settings/all-units+decimals} _]
    {:fx (into []
               (for [[domain settings]                                                    units-settings
-                    [_ domain-name domain-uuid domain-dimension-uuid unit-uuid decimals] settings]
+                    [_ domain-name domain-uuid domain-dimension-uuid
+                     cached-unit-uuid native-domain-unit-uuid
+                     english-domain-unit-uuid metric-domain-unit-uuid decimals] settings]
                 [:dispatch [:settings/set [:units domain domain-uuid]
-                            {:domain-name             domain-name
-                             :domain-dimension-uuid   domain-dimension-uuid
-                             :domain-native-unit-uuid unit-uuid
-                             :domain-decimals         decimals}]]))}))
+                            {:domain-name              domain-name
+                             :domain-dimension-uuid    domain-dimension-uuid
+                             :domain-cached-unit-uuid  cached-unit-uuid
+                             :domain-native-unit-uuid  native-domain-unit-uuid
+                             :domain-english-unit-uuid english-domain-unit-uuid
+                             :domain-metric-unit-uuid  metric-domain-unit-uuid
+                             :domain-decimals          decimals}]]))}))
 
 (rf/reg-event-fx
  :settings/reset-custom-unit-preferences
@@ -68,3 +73,10 @@
 
      (vector? k)
      (assoc-in settings k v))))
+
+
+(rf/reg-event-fx
+ :settings/set-units-system
+ (fn [_ [_ units-system]]
+   {:fx [[:dispatch [:settings/set [:units-system] units-system]]
+         [:dispatch [:local-storage/update-in [:units-system] units-system]]]}))

--- a/projects/behave/src/cljs/behave/settings/events.cljs
+++ b/projects/behave/src/cljs/behave/settings/events.cljs
@@ -79,4 +79,5 @@
  :settings/set-units-system
  (fn [_ [_ units-system]]
    {:fx [[:dispatch [:settings/set [:units-system] units-system]]
-         [:dispatch [:local-storage/update-in [:units-system] units-system]]]}))
+         [:dispatch [:local-storage/update-in [:units-system] units-system]]
+         [:dispatch [:state/set [:tool :data] nil]]]}))

--- a/projects/behave/src/cljs/behave/settings/events.cljs
+++ b/projects/behave/src/cljs/behave/settings/events.cljs
@@ -32,10 +32,16 @@
 
  (fn [{units-settings :settings/all-units+decimals} _]
    {:fx (into []
-              (for [[domain settings]                                                    units-settings
-                    [_ domain-name domain-uuid domain-dimension-uuid
-                     cached-unit-uuid native-domain-unit-uuid
-                     english-domain-unit-uuid metric-domain-unit-uuid decimals] settings]
+              (for [[domain settings] units-settings
+                    [_
+                     domain-name
+                     domain-uuid
+                     domain-dimension-uuid
+                     cached-unit-uuid
+                     native-domain-unit-uuid
+                     english-domain-unit-uuid
+                     metric-domain-unit-uuid
+                     decimals]        settings]
                 [:dispatch [:settings/set [:units domain domain-uuid]
                             {:domain-name              domain-name
                              :domain-dimension-uuid    domain-dimension-uuid

--- a/projects/behave/src/cljs/behave/settings/subs.cljs
+++ b/projects/behave/src/cljs/behave/settings/subs.cljs
@@ -62,7 +62,14 @@
                                   [(get-else $ ?d :domain/decimals "N/A") ?decimals]]
                                 @@vms-conn)
                            (sort-by (juxt first second)))]
-     (->> (map (fn [[v-domain v-name v-uuid v-dimension-uuid native-domain-unit-uuid default-decimals english-domain-unit-uuid metric-domain-unit-uuid]]
+     (->> (map (fn [[v-domain
+                     v-name
+                     v-uuid
+                     v-dimension-uuid
+                     native-domain-unit-uuid
+                     default-decimals
+                     english-domain-unit-uuid
+                     metric-domain-unit-uuid]]
                  (let [{:keys [unit-uuid decimals]} (get cached-units v-uuid)]
                    (-> [v-domain v-name v-uuid v-dimension-uuid]
                        (into [unit-uuid

--- a/projects/behave/src/cljs/behave/settings/views.cljs
+++ b/projects/behave/src/cljs/behave/settings/views.cljs
@@ -82,32 +82,31 @@
     (let [*state-settings (rf/subscribe [:settings/get :units])
           domain-sets     (sort-by first @*state-settings)]
       [:div.settings__general-units
-       [c/radio-group
-        {:label   "Units System"
-         :name    "Units System"
-         :options [{:value     :english
-                    :label     "English"
-                    :on-change #(rf/dispatch [:settings/set-units-system :english])
-                    :checked?  (= @(rf/subscribe [:settings/units-system]) :english)}
-                   {:value     :metric
-                    :label     "Metric"
-                    :on-change #(rf/dispatch [:settings/set-units-system :metric])
-                    :checked?  (= @(rf/subscribe [:settings/units-system]) :metric)}
-                   ]}]
-       (c/accordion {:accordion-items (for [[domain-set-name domain-unit-settings] domain-sets]
-                                        ^{:key domain-sets}
-                                        {:label   domain-set-name
-                                         :content (c/table {:headers [@(<t (bp "variable_domain"))
-                                                                      @(<t (bp "units"))
-                                                                      @(<t (bp "decimals"))]
-                                                            :columns [:domain :units :decimals]
-                                                            :rows    (build-rows
-                                                                      ws-uuid
-                                                                      domain-set-name
-                                                                      (sort-by
-                                                                       (fn [[_ domain]]
-                                                                         (:domain-name domain))
-                                                                       domain-unit-settings))})})})])))
+       [:div.settings__general-units__units-system-selection
+        [c/radio-group
+         {:label   "Units System"
+          :name    "Units System"
+          :options [{:label     "English"
+                     :on-change #(rf/dispatch [:settings/set-units-system :english])
+                     :checked?  (= @(rf/subscribe [:settings/units-system]) :english)}
+                    {:label     "Metric"
+                     :on-change #(rf/dispatch [:settings/set-units-system :metric])
+                     :checked?  (= @(rf/subscribe [:settings/units-system]) :metric)}]}]]
+       [:div.settings__general-units__table
+        (c/accordion {:accordion-items (for [[domain-set-name domain-unit-settings] domain-sets]
+                                         ^{:key domain-sets}
+                                         {:label   domain-set-name
+                                          :content (c/table {:headers [@(<t (bp "variable_domain"))
+                                                                       @(<t (bp "units"))
+                                                                       @(<t (bp "decimals"))]
+                                                             :columns [:domain :units :decimals]
+                                                             :rows    (build-rows
+                                                                       ws-uuid
+                                                                       domain-set-name
+                                                                       (sort-by
+                                                                        (fn [[_ domain]]
+                                                                          (:domain-name domain))
+                                                                        domain-unit-settings))})})})]])))
 
 
 ;;==============================================================================

--- a/projects/behave/src/cljs/behave/solver/core.cljs
+++ b/projects/behave/src/cljs/behave/solver/core.cljs
@@ -82,11 +82,13 @@
     (apply f module fn-args)))
 
 (defn apply-output-cpp-fn
-  [module-fns module gv-id unit-uuid]
-  (let [[fn-id fn-name] (q/group-variable->fn gv-id)
+  [ws-uuid module-fns module gv-uuid unit-uuid]
+  (let [[fn-id fn-name] (q/group-variable->fn gv-uuid)
         unit            (q/unit-uuid->enum-value unit-uuid)
         f               ((symbol fn-name) module-fns)
         params          (q/fn-params fn-id)]
+
+    (rf/dispatch [:worksheet/insert-output-units ws-uuid gv-uuid unit-uuid])
 
     (log-solver [:OUTPUT fn-name unit f params])
 
@@ -124,22 +126,24 @@
         (log-solver [:MULTI repeat-group])
         (apply-multi-cpp-fn fns module repeat-group)))))
 
-(defn get-outputs [module fns outputs]
+(defn get-outputs [ws-uuid module fns outputs]
   (let [units-system @(rf/subscribe [:settings/units-system])]
-   (reduce
-    (fn [acc group-variable-uuid]
-      (let [var-uuid     (q/variable-uuid group-variable-uuid)
-            *var-entity  (rf/subscribe [:vms/entity-from-uuid var-uuid])
-            domain-uuid  (:variable/domain-uuid @*var-entity)
-            *cached-unit (rf/subscribe [:settings/cached-unit domain-uuid])
-            unit-uuid    (or @*cached-unit
-                             (q/variable-units-uuid group-variable-uuid units-system)
-                             :none)
-            result       (str (apply-output-cpp-fn fns module group-variable-uuid unit-uuid))]
-        (log-solver [:GET-OUTPUTS group-variable-uuid result unit-uuid])
-        (assoc acc group-variable-uuid [result unit-uuid])))
-    {}
-    outputs)))
+    (reduce
+     (fn [acc group-variable-uuid]
+       (let [var-uuid             (q/variable-uuid group-variable-uuid)
+             *var-entity          (rf/subscribe [:vms/entity-from-uuid var-uuid])
+             domain-uuid          (:variable/domain-uuid @*var-entity)
+             *cached-unit         (rf/subscribe [:settings/cached-unit domain-uuid])
+             worksheet-units-uuid (rf/subscribe [:settings/cached-unit ws-uuid group-variable-uuid])
+             unit-uuid            (or @worksheet-units-uuid
+                                      @*cached-unit
+                                      (q/variable-units-uuid group-variable-uuid units-system)
+                                      :none)
+             result               (str (apply-output-cpp-fn ws-uuid fns module group-variable-uuid unit-uuid))]
+         (log-solver [:GET-OUTPUTS group-variable-uuid result unit-uuid])
+         (assoc acc group-variable-uuid [result unit-uuid])))
+     {}
+     outputs)))
 
 ;;; Links
 (defn add-links [{:keys [gv-uuids] :as module}]
@@ -176,7 +180,7 @@
      (fn [acc [src-uuid dst-uuid]]
        (if (input-gv-uuids src-uuid)
          (let [[src-group-uuid _ _ value unit-uuid] (get inputs-by-gv-uuid src-uuid)
-               group-uuid              (q/group-variable->group dst-uuid)]
+               group-uuid                           (q/group-variable->group dst-uuid)]
            (log-solver [:ADD-LINK
                         [:SRC src-group-uuid 0 src-uuid [value unit-uuid]]
                         [:DST group-uuid 0 dst-uuid [value unit-uuid]]])
@@ -199,10 +203,10 @@
                           destination-links
                           diagrams
                           ws-uuid]}]
-  (let [module         (init-fn)
+  (let [module (init-fn)
         ;; Apply links
-        inputs         (apply-output-links outputs inputs destination-links)
-        inputs         (apply-input-links inputs destination-links)
+        inputs (apply-output-links outputs inputs destination-links)
+        inputs (apply-input-links inputs destination-links)
 
         ;; Filter IO's for module
         module-inputs  (filter-module-inputs inputs gv-uuids)
@@ -223,7 +227,7 @@
                           :module   module})
 
     ;; Get outputs, merge existing inputs/outputs with new inputs/outputs
-    (update row :outputs merge (get-outputs module fns module-outputs))))
+    (update row :outputs merge (get-outputs ws-uuid module fns module-outputs))))
 
 (defn remove-source-link-outputs [row surface-module]
   (let [{:keys [outputs all-outputs]} row
@@ -237,18 +241,22 @@
          all-inputs  @(rf/subscribe [:worksheet/all-inputs+units-vector ws-uuid])
          all-outputs @(rf/subscribe [:worksheet/all-output-uuids ws-uuid])]
 
+     (doseq [[group-uuid repeat-id gv-uuid _value unit-uuid] all-inputs]
+       (when (not= unit-uuid :none)
+         (rf/dispatch [:worksheet/update-input-units ws-uuid group-uuid repeat-id gv-uuid unit-uuid])))
+
      (-> (solve-worksheet ws-uuid modules all-inputs all-outputs)
          (t/add-to-results-table ws-uuid))))
 
   ([ws-uuid modules all-inputs all-outputs]
    (let [counter (atom 0)
          surface-module
-         (-> {:init-fn     surface/init
-              :run-fn      surface/doSurfaceRun
-              :fns         (ns-publics 'behave.lib.surface)
-              :gv-uuids    (q/class-to-group-variables "SIGSurface")
-              :diagrams    (q/module-diagrams "surface")
-              :ws-uuid     ws-uuid}
+         (-> {:init-fn  surface/init
+              :run-fn   surface/doSurfaceRun
+              :fns      (ns-publics 'behave.lib.surface)
+              :gv-uuids (q/class-to-group-variables "SIGSurface")
+              :diagrams (q/module-diagrams "surface")
+              :ws-uuid  ws-uuid}
              (add-links))
 
          crown-module
@@ -259,12 +267,12 @@
              (add-links))
 
          contain-module
-         (-> {:init-fn     contain/init
-              :run-fn      contain/doContainRun
-              :fns         (ns-publics 'behave.lib.contain)
-              :gv-uuids    (q/class-to-group-variables "SIGContainAdapter")
-              :diagrams    (q/module-diagrams "contain")
-              :ws-uuid     ws-uuid}
+         (-> {:init-fn  contain/init
+              :run-fn   contain/doContainRun
+              :fns      (ns-publics 'behave.lib.contain)
+              :gv-uuids (q/class-to-group-variables "SIGContainAdapter")
+              :diagrams (q/module-diagrams "contain")
+              :ws-uuid  ws-uuid}
              (add-links))
 
          mortality-module

--- a/projects/behave/src/cljs/behave/solver/queries.cljs
+++ b/projects/behave/src/cljs/behave/solver/queries.cljs
@@ -45,9 +45,9 @@
 (defn parsed-value [group-variable-uuid value]
   (let [kind (variable-kind group-variable-uuid)]
     (condp = kind
-      :discrete       (if (is-digit? value) (parse-int value) value)
-      :continuous     (parse-float value)
-      :text           value)))
+      :discrete   (if (is-digit? value) (parse-int value) value)
+      :continuous (parse-float value)
+      :text       value)))
 
 (defn fn-params
   "Given an Function entity id, return a sequence of parameter info.
@@ -82,6 +82,31 @@
             :domain/native-unit-uuid)
         (-> var-entity
             :variable/native-unit-uuid))))
+
+(defn variable-units-uuid
+  "Given a uuid  and a keyword #{:native :english :metric} for a group-variable return either the native-unit uuid from its associated domain
+  entity or from it's assocated variable entity."
+  [group-variable-uuid units-system]
+  (let [var-entity (variable group-variable-uuid)]
+    (case units-system
+      :native  (or (-> var-entity
+                       :variable/domain-uuid
+                       uuid->entity
+                       :domain/native-unit-uuid)
+                   (-> var-entity
+                       :variable/native-unit-uuid))
+      :english (or (-> var-entity
+                       :variable/domain-uuid
+                       uuid->entity
+                       :domain/english-unit-uuid)
+                   (-> var-entity
+                       :variable/english-unit-uuid))
+      :metric  (or (-> var-entity
+                      :variable/domain-uuid
+                      uuid->entity
+                      :domain/metric-unit-uuid)
+                  (-> var-entity
+                      :variable/metric-unit-uuid)))))
 
 (defn unit-uuid->enum-value
   "Given a uuid to a unit entity return the enum value for that unit."
@@ -153,14 +178,14 @@
   "Given a prameter entity id return the uuid for it's associated group variable."
   [parameter-id]
   (let [param-uuid (->> parameter-id
-                       (d/entity @@vms-conn)
-                       :bp/uuid)]
+                        (d/entity @@vms-conn)
+                        :bp/uuid)]
     (d/q '[:find  ?gv-uuid .
            :in    $ ?p-uuid
            :where
            [?gv :group-variable/cpp-parameter ?p-uuid]
            [?gv :bp/uuid ?gv-uuid]]
-          @@vms-conn param-uuid)))
+         @@vms-conn param-uuid)))
 
 (defn class-to-group-variables
   "Given a class-name (i.e. SIGSurface), return a list of group-variable uuids that belong to that
@@ -174,7 +199,7 @@
           [?c :bp/uuid ?c-uuid]
           [?gv :group-variable/cpp-class ?c-uuid]
           [?gv :bp/uuid ?gv-uuid]]
-         @@vms-conn class-name)))
+        @@vms-conn class-name)))
 
 (defn class-to-subtool-variables
   "Given a class-name (i.e. SIGSlopeTool), return a list of subtool-variable uuids that belong to that
@@ -188,7 +213,7 @@
           [?c :bp/uuid ?c-uuid]
           [?sv :subtool-variable/cpp-class-uuid ?c-uuid]
           [?sv :bp/uuid ?sv-uuid]]
-         @@vms-conn class-name)))
+        @@vms-conn class-name)))
 
 (defn source-links
   "Given a colleciton of group-variable uuids return a map of the given uuids to it's associated `:link/destination`."

--- a/projects/behave/src/cljs/behave/solver/queries.cljs
+++ b/projects/behave/src/cljs/behave/solver/queries.cljs
@@ -71,18 +71,6 @@
       variable
       :bp/uuid))
 
-(defn variable-native-units-uuid
-  "Given a uuid for a group-variable return either the native-unit uuid from its associated domain
-  entity or from it's assocated variable entity."
-  [group-variable-uuid]
-  (let [var-entity (variable group-variable-uuid)]
-    (or (-> var-entity
-            :variable/domain-uuid
-            uuid->entity
-            :domain/native-unit-uuid)
-        (-> var-entity
-            :variable/native-unit-uuid))))
-
 (defn variable-units-uuid
   "Given a uuid  and a keyword #{:native :english :metric} for a group-variable return either the native-unit uuid from its associated domain
   entity or from it's assocated variable entity."

--- a/projects/behave/src/cljs/behave/tool/events.cljs
+++ b/projects/behave/src/cljs/behave/tool/events.cljs
@@ -54,7 +54,7 @@
                            subtool-uuid
                            :tool/outputs
                            variable-uuid
-                           :output/units-uuid]
+                           :output/units-uuid-uuid]
                           unit-uuid)}
      auto-compute? (assoc :fx [[:dispatch [:tool/solve tool-uuid subtool-uuid]]]))))
 

--- a/projects/behave/src/cljs/behave/tool/solver.cljs
+++ b/projects/behave/src/cljs/behave/tool/solver.cljs
@@ -82,7 +82,7 @@
                        units-enum   (q/unit-uuid->enum-value units-uuid)
                        output-value (apply-output-cpp-fn fns tool-obj output-uuid units-enum)]
                    [output-uuid {:output/value      (format-intl-number "en-US" output-value 2)
-                                 :output/units-uuid units-uuid}]))
+                                 :output/units-uuid-uuid units-uuid}]))
                outputs))))
 
 (defn- get-compute-fn [subtool-uuid fns]

--- a/projects/behave/src/cljs/behave/tool/solver.cljs
+++ b/projects/behave/src/cljs/behave/tool/solver.cljs
@@ -81,9 +81,6 @@
                                         (q/variable-units-uuid output-uuid units-system))
                        units-enum   (q/unit-uuid->enum-value units-uuid)
                        output-value (apply-output-cpp-fn fns tool-obj output-uuid units-enum)]
-                   (prn "selected-unit: " selected-unit)
-                   (prn "(q/variable-units-uuid output-uuid units-system):" (q/variable-units-uuid output-uuid units-system))
-                   (prn "units-enum: " (q/unit-uuid->enum-value units-uuid))
                    [output-uuid {:output/value      (format-intl-number "en-US" output-value 2)
                                  :output/units-uuid units-uuid}]))
                outputs))))

--- a/projects/behave/src/cljs/behave/tool/subs.cljs
+++ b/projects/behave/src/cljs/behave/tool/subs.cljs
@@ -136,7 +136,7 @@
                                         subtool-uuid
                                         :tool/outputs
                                         output-uuid
-                                        :output/units-uuid])])))))
+                                        :output/units-uuid-uuid])])))))
 
 (comment
   (rf/subscribe [:tool/all-inputs

--- a/projects/behave/src/cljs/behave/wizard/subs.cljs
+++ b/projects/behave/src/cljs/behave/wizard/subs.cljs
@@ -920,7 +920,6 @@
    (subscribe [:worksheet/modules ws-uuid]))
 
  (fn [modules _]
-   (prn ":wizard/search-table-output-group-variables")
    (letfn [(get-search-table-filter-output-group-variables [module-eid]
              (d/q '[:find [?gv ...]
                     :in $ % ?module-eid

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -191,6 +191,15 @@
      {:transact payload})))
 
 (rp/reg-event-fx
+ :worksheet/insert-output-units
+ [(rf/inject-cofx ::inject/sub (fn [[_ ws-uuid gv-uuid]] [:worksheet/output-eid ws-uuid gv-uuid]))]
+ (fn [{output-eid :worksheet/output-eid} [_ _ gv-uuid unit-uuid]]
+   (when output-eid
+     (let [payload [{:db/id        output-eid
+                     :output/units unit-uuid}]]
+       {:transact payload}))))
+
+(rp/reg-event-fx
  :worksheet/delete-repeat-input-group
  [(rp/inject-cofx :ds)]
  (fn [{:keys [ds]} [_ ws-uuid group-uuid repeat-id]]

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -522,17 +522,17 @@
  (fn [_ [_ ws-uuid]]
    {:type      :query
     :query     '[:find ?group-var-uuid ?min ?max
-             :in   $ ?ws-uuid
-             :where
-             [?w :worksheet/uuid ?ws-uuid]
-             [?w :worksheet/graph-settings ?g]
-             [?g :graph-settings/y-axis-limits ?y]
-             [?y :y-axis-limit/group-variable-uuid ?group-var-uuid]
-             [?y :y-axis-limit/min ?min]
-             [?y :y-axis-limit/max ?max]
-             [?w :worksheet/outputs ?o]
-             [?o :output/group-variable-uuid ?group-var-uuid]
-             [?o :output/enabled? true]]
+                 :in   $ ?ws-uuid
+                 :where
+                 [?w :worksheet/uuid ?ws-uuid]
+                 [?w :worksheet/graph-settings ?g]
+                 [?g :graph-settings/y-axis-limits ?y]
+                 [?y :y-axis-limit/group-variable-uuid ?group-var-uuid]
+                 [?y :y-axis-limit/min ?min]
+                 [?y :y-axis-limit/max ?max]
+                 [?w :worksheet/outputs ?o]
+                 [?o :output/group-variable-uuid ?group-var-uuid]
+                 [?o :output/enabled? true]]
     :variables [ws-uuid]}))
 
 (rf/reg-sub
@@ -573,18 +573,18 @@
  (fn [_ [_ ws-uuid]]
    {:type      :query
     :query     '[:find ?group-var-uuid ?min ?max ?enabled
-             :in   $ ?ws-uuid
-             :where
-             [?w :worksheet/uuid ?ws-uuid]
-             [?w :worksheet/table-settings ?ts]
-             [?ts :table-settings/filters ?tf]
-             [?tf :table-filter/group-variable-uuid ?group-var-uuid]
-             [?tf :table-filter/min ?min]
-             [?tf :table-filter/max ?max]
-             [?tf :table-filter/enabled? ?enabled]
-             [?w :worksheet/outputs ?o]
-             [?o :output/group-variable-uuid ?group-var-uuid]
-             [?o :output/enabled? true]]
+                 :in   $ ?ws-uuid
+                 :where
+                 [?w :worksheet/uuid ?ws-uuid]
+                 [?w :worksheet/table-settings ?ts]
+                 [?ts :table-settings/filters ?tf]
+                 [?tf :table-filter/group-variable-uuid ?group-var-uuid]
+                 [?tf :table-filter/min ?min]
+                 [?tf :table-filter/max ?max]
+                 [?tf :table-filter/enabled? ?enabled]
+                 [?w :worksheet/outputs ?o]
+                 [?o :output/group-variable-uuid ?group-var-uuid]
+                 [?o :output/enabled? true]]
     :variables [ws-uuid]}))
 
 (rf/reg-sub
@@ -979,24 +979,24 @@
  (fn [_ [_ ws-uuid row-id]]
    {:type  :query
     :query '[:find  ?gv-uuid ?value ?units
-                 :in $ ?ws-uuid ?row-id
-                 :where
-                 [?ws :worksheet/uuid ?ws-uuid]
-                 [?ws :worksheet/input-groups ?ig]
-                 [?ws :worksheet/result-table ?t]
-                 [?t  :result-table/rows ?rr]
-                 [?rr :result-row/id ?row-id]
-                 [?rr :result-row/cells ?c]
+             :in $ ?ws-uuid ?row-id
+             :where
+             [?ws :worksheet/uuid ?ws-uuid]
+             [?ws :worksheet/input-groups ?ig]
+             [?ws :worksheet/result-table ?t]
+             [?t  :result-table/rows ?rr]
+             [?rr :result-row/id ?row-id]
+             [?rr :result-row/cells ?c]
 
-                 ;; Filter only input variables
-                 [?ig :input-group/inputs ?i]
-                 [?i  :input/group-variable-uuid ?gv-uuid]
+             ;; Filter only input variables
+             [?ig :input-group/inputs ?i]
+             [?i  :input/group-variable-uuid ?gv-uuid]
 
-                 ;; Get  gv-uuid, value and units
-                 [?rh :result-header/group-variable-uuid ?gv-uuid]
-                 [?rh :result-header/units ?units]
-                 [?c  :result-cell/header ?rh]
-                 [?c  :result-cell/value ?value]]
+             ;; Get  gv-uuid, value and units
+             [?rh :result-header/group-variable-uuid ?gv-uuid]
+             [?rh :result-header/units ?units]
+             [?c  :result-cell/header ?rh]
+             [?c  :result-cell/value ?value]]
     :variables [ws-uuid row-id]}))
 
 (rp/reg-sub
@@ -1004,23 +1004,23 @@
  (fn [_ [_ ws-uuid row-id]]
    {:type  :query
     :query '[:find  ?gv-uuid ?value ?units
-                 :in $ ?ws-uuid ?row-id
-                 :where
-                 [?ws :worksheet/uuid ?ws-uuid]
-                 [?ws :worksheet/outputs ?o]
-                 [?ws :worksheet/result-table ?t]
-                 [?t  :result-table/rows ?rr]
-                 [?rr :result-row/id ?row-id]
-                 [?rr :result-row/cells ?c]
+             :in $ ?ws-uuid ?row-id
+             :where
+             [?ws :worksheet/uuid ?ws-uuid]
+             [?ws :worksheet/outputs ?o]
+             [?ws :worksheet/result-table ?t]
+             [?t  :result-table/rows ?rr]
+             [?rr :result-row/id ?row-id]
+             [?rr :result-row/cells ?c]
 
-                 ;; Filter only output variables
-                 [?o  :output/group-variable-uuid  ?gv-uuid]
+             ;; Filter only output variables
+             [?o  :output/group-variable-uuid  ?gv-uuid]
 
-                 ;; Get  gv-uuid, value and units
-                 [?rh :result-header/group-variable-uuid ?gv-uuid]
-                 [?rh :result-header/units ?units]
-                 [?c  :result-cell/header ?rh]
-                 [?c  :result-cell/value ?value]]
+             ;; Get  gv-uuid, value and units
+             [?rh :result-header/group-variable-uuid ?gv-uuid]
+             [?rh :result-header/units ?units]
+             [?c  :result-cell/header ?rh]
+             [?c  :result-cell/value ?value]]
     :variables [ws-uuid row-id]}))
 
 (rf/reg-sub
@@ -1146,3 +1146,31 @@
    (rf/subscribe [:worksheet/modules ws-uuid]))
  (fn [modules]
    (mapcat :module/search-tables modules)))
+
+
+(rf/reg-sub
+ :worksheet/output-eid
+ (fn [_ [_ ws-uuid gv-uuid]]
+   (d/q '[:find  ?o .
+          :in  $ ?ws-uuid ?gv-uuid
+          :where
+          [?w :worksheet/uuid ?ws-uuid]
+          [?w :worksheet/outputs ?o]
+          [?o :output/group-variable-uuid ?gv-uuid]]
+        @@s/conn
+        ws-uuid
+        gv-uuid)))
+
+(rf/reg-sub
+ :worksheet/output-unit-uuid
+ (fn [_ [_ ws-uuid gv-uuid]]
+   (d/q '[:find  ?unit-uuid .
+          :in  $ ?ws-uuid ?gv-uuid
+          :where
+          [?w :worksheet/uuid ?ws-uuid]
+          [?w :worksheet/outputs ?o]
+          [?o :output/group-variable-uuid ?gv-uuid]
+          [?o :output/units ?unit-uuid]]
+        @@s/conn
+        ws-uuid
+        gv-uuid)))

--- a/projects/behave/test/cljs/behave/worksheet_events_test.cljs
+++ b/projects/behave/test/cljs/behave/worksheet_events_test.cljs
@@ -94,7 +94,7 @@
             :input-group/repeat-id  repeat-id
             :input-group/inputs     [{:input/group-variable-uuid group-variable-uuid
                                       :input/value               value
-                                      :input/units               units}]}))))
+                                      :input/units-uuid          units}]}))))
 
 (deftest upsert-input-variable-with-non-existing-group-uuid-test
   (let [*worksheet                   (rf/subscribe [:worksheet fx/test-ws-uuid])

--- a/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/domains/views.cljs
@@ -61,7 +61,6 @@
           on-delete
           #(when (js/confirm (str "Are you sure you want to delete the domain " (:domain/name %) "?"))
              (rf/dispatch [:api/delete-entity %]))]
-      (prn "domain:" @domain)
       [:div
        {:style {:height "400px"}}
        [simple-table


### PR DESCRIPTION
## Purpose

## Related Issues
Closes BHP1-1246

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open local App and Navigate to Settings
2. Ensure there is now an option to switch units system between English and Metric
3. Expand an accordion
4. Change units to "Metric" and ensure "units" column all change accordingly
5. Create a worksheet and ensure any "continuous" inputs (i.e. wind speed) is defaulted to it's metric unit
7. Run the worksheet and ensure results are also in metric
8. Change units system back to "English" and re-run worksheet
9. Ensure the inputs and results are now in "English" units
10. Open a tools and repeat steps 4-9

## Screenshots