### PR TITLE
[BHP1-1437] Use native / domain decimals to format tool outputs

### DIFF
--- a/components/browser_utils/src/browser_utils/core.cljs
+++ b/components/browser_utils/src/browser_utils/core.cljs
@@ -169,9 +169,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Format International Number
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn format-intl-number [locale number & [significant-digits]]
+(defn format-intl-number
+  "Formats a number according to it's international number format (with significant digits).
+
+  Usage:
+  `(format-intl-number \"en-US\" 0.09393923 2) ; => 0.09`
+  "
+  [locale number & [significant-digits]]
   (.format (js/Intl.NumberFormat. locale #js {:maximumSignificantDigits (or significant-digits 3)})
            number))
 
-;; Usage
-;; (format-intl-number "en-US" 0.09393923 2) ; => 0.09

--- a/components/browser_utils/src/browser_utils/interface.cljs
+++ b/components/browser_utils/src/browser_utils/interface.cljs
@@ -4,3 +4,7 @@
 (def ^{:argslist '([f wait])
        :doc "Creates a debounced function which delays invocation until after `wait` ms have elapsed since the last time function was invoked."}
   debounce c/debounce)
+
+(def ^{:argslist '([locale number] [locale number significant-digits])
+       :doc "Creates a debounced function which delays invocation until after `wait` ms have elapsed since the last time function was invoked."}
+  format-intl-number c/format-intl-number)

--- a/components/number_utils/src/number_utils/core.cljc
+++ b/components/number_utils/src/number_utils/core.cljc
@@ -42,8 +42,10 @@
 (defn to-precision
   "Rounds a double to n significant digits."
   [dbl n]
-  (let [factor (.pow #?(:clj Math :cljs js/Math) 10 n)]
-    (/ (Math/round (* dbl factor)) factor)))
+  (let [factor (Math/pow 10 n)]
+    (cond-> (/ (Math/round (* dbl factor)) factor)
+      (= n 0)
+      (int))))
 
 (defn decimal-precision
   "Sets a decimal to precision specific."


### PR DESCRIPTION
-------

## Purpose
EOM

## Related Issues
Closes BHP1-1437

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Run the Relative Humidity tool with the following:
  - Dry Bulb Temperature: 80 oF
  - Wet Bulb Temperature: 40 oF
  - Site Elevation: 500
2. Verify that:
  - The Relative Humidity output is in whole percent (1%)
  
3. Click through other calculators with % outputs, verify that no
   outputs have decimal places.