### PR TITLE
[BHP1-1436] Updates Safey Condition Colors, fix tag color editing

### DIFF
--- a/development/migrations/2025_10_01_update_ssd_colors.clj
+++ b/development/migrations/2025_10_01_update_ssd_colors.clj
@@ -1,0 +1,60 @@
+(ns migrations.2025-10-01-update-ssd-colors
+  (:require [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+(defn- find-tag-eid
+  [conn tag-set-name tag-name]
+  (d/q '[:find ?t .
+         :in $ ?set-name ?tag-name
+         :where
+         [?e :tag-set/name ?set-name]
+         [?e :tag-set/tags ?t]
+         [?t :tag/name ?tag-name]]
+       (d/db conn) tag-set-name tag-name))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def moderate-tag-eid (find-tag-eid conn "Safety Conditions" "Moderate"))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def extreme-tag-eid (find-tag-eid conn "Safety Conditions" "Extreme"))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload
+  [{:db/id     moderate-tag-eid
+    :tag/color "#FFDA0D"}
+   {:db/id     extreme-tag-eid
+    :tag/color "#CB5757"}])
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (def tx-data (d/transact conn payload)))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))
+

--- a/projects/behave_cms/src/cljs/behave_cms/tags/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/tags/views.cljs
@@ -29,7 +29,7 @@
 
                                   {:label     "Color"
                                    :type      :color
-                                   :disabled? (:tag-set/color? @tag-set)
+                                   :disabled? (not (:tag-set/color? @tag-set))
                                    :field-key :tag/color}]
                    :on-create    (fn [data]
                                    (let [translation (upsert-translation (:tag/translation-key data) (:tag/name data))]


### PR DESCRIPTION
-------

## Purpose
1. Migration to update the Safety Conditions
2. Fixes the Color Tag editor

## Related Issues
Closes BHP1-1436

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Run migration `migrations.2025-10-01-update-ssd-colors`, sync
2. Run the "Safe Separation Distance" tool with:
   - Burning Condition/Slope Class/Wind Speed Class: Moderate
   - Vegetation Height: 10 ft
3. Verify that the color for "Moderate" is a gold yellow
4. Run the "Safe Separation Distance" tool with:
   - Burning Condition: Extreme
   - Slope Class: Steep
   - Wind Speed Class: High
   - Vegetation Height: 10 ft
3. Verify that the color for "Extreme" is a bronze red

## Screenshots
<img width="769" height="463" alt="CleanShot 2025-10-01 at 16 13 42" src="https://github.com/user-attachments/assets/c9f8fcb7-ace9-4849-bf8b-f4f497cba1d1" />

<img width="759" height="452" alt="CleanShot 2025-10-01 at 16 13 49" src="https://github.com/user-attachments/assets/94a1ed1f-869c-4f44-8cde-05dcdfe8d9b6" />
