### PR TITLE
[BHP1-1444] Fix Fuel Models Selection not Saving

### DIFF
--- a/bases/behave_components/src/cljs/behave/components/inputs.cljs
+++ b/bases/behave_components/src/cljs/behave/components/inputs.cljs
@@ -227,7 +227,7 @@
     [icon (if selected? "minus" "plus")]]
    label])
 
-(defn- manage-multi-select-fn
+(defn- multi-select-on-select
   [selections-atom selection disable-multi-valued-input?]
   (let [[_label value on-deselect on-select] selection]
     (if (contains? @selections-atom selection)
@@ -318,7 +318,7 @@
               [multi-select-option {:selected? (contains? @selections selection)
                                     :color-tag color-tag
                                     :label     label
-                                    :on-click  #(manage-multi-select-fn selections selection disable-multi-valued-input?)}])))]])
+                                    :on-click  #(multi-select-on-select selections selection disable-multi-valued-input?)}])))]])
      [:div.multi-select__selections
       [:div.multi-select__selections__header
        [:div (gstring/format "Selected %s" input-label)]
@@ -404,7 +404,7 @@
                    :on-key-press (on-enter (fn []
                                              (when-let [{:keys [label value on-deselect on-select]} (first @filtered-options)]
                                                (let [selection [label value on-deselect on-select]]
-                                                 (manage-multi-select-fn selections selection disable-multi-valued-input?))
+                                                 (multi-select-on-select selections selection disable-multi-valued-input?))
                                                (reset! search nil))))
                    :on-change    #(do (reset! search (input-value %))
                                       (reset! filtered-options (filter (fn [option]
@@ -428,5 +428,5 @@
                                    :color-tag color-tag
                                    :label     label
                                    :on-click  #(do
-                                                 (manage-multi-select-fn selections selection disable-multi-valued-input?)
+                                                 (multi-select-on-select selections selection disable-multi-valued-input?)
                                                  (reset! search nil))}])))])]))

--- a/bases/behave_components/src/cljs/behave/components/inputs.cljs
+++ b/bases/behave_components/src/cljs/behave/components/inputs.cljs
@@ -227,6 +227,22 @@
     [icon (if selected? "minus" "plus")]]
    label])
 
+(defn- manage-multi-select-fn
+  [selections-atom selection disable-multi-valued-input?]
+  (let [[_label value on-deselect on-select] selection]
+    (if (contains? @selections-atom selection)
+      (do
+        (reset! selections-atom (disj @selections-atom selection))
+        (when on-deselect (on-deselect value)))
+      (if disable-multi-valued-input?
+        (do
+          (when on-deselect (doseq [[_ value on-deselect] @selections-atom] (on-deselect value)))
+          (when on-select (on-select value))
+          (reset! selections-atom (into (sorted-set) [selection])))
+        (do
+          (when on-select (on-select value))
+          (reset! selections-atom (conj @selections-atom selection)))))))
+
 (defmulti multi-select-input
   "Creates a multi-select input component with the following options:
   - `input-label`: text to display as the label for the input.
@@ -298,21 +314,11 @@
                                       (and filter-tags @selected-tag)
                                       (filter (fn [id] (contains? (:tags id) @selected-tag))))]
             ^{:key label}
-            (let [selection [label value on-deselect]]
+            (let [selection [label value on-deselect on-select]]
               [multi-select-option {:selected? (contains? @selections selection)
                                     :color-tag color-tag
                                     :label     label
-                                    :on-click  #(do (if (contains? @selections selection)
-                                                      (do
-                                                        (reset! selections (disj @selections selection))
-                                                        (when on-deselect (on-deselect value)))
-                                                      (do
-                                                        (if disable-multi-valued-input?
-                                                          (reset! selections (into (sorted-set) [selection]))
-                                                          (do
-                                                            (reset! selections (conj @selections selection))
-                                                            (when on-select
-                                                              (on-select value)))))))}])))]])
+                                    :on-click  #(manage-multi-select-fn selections selection disable-multi-valued-input?)}])))]])
      [:div.multi-select__selections
       [:div.multi-select__selections__header
        [:div (gstring/format "Selected %s" input-label)]
@@ -397,14 +403,8 @@
       [text-input {:label        "Search"
                    :on-key-press (on-enter (fn []
                                              (when-let [{:keys [label value on-deselect on-select]} (first @filtered-options)]
-                                               (if disable-multi-valued-input?
-                                                 (do
-                                                   (when on-deselect (doseq [[_ value on-deselect] @selections] (on-deselect value)))
-                                                   (when on-select (on-select value))
-                                                   (reset! selections (into (sorted-set) [[label value on-deselect]])))
-                                                 (do
-                                                   (when on-select (on-select value))
-                                                   (reset! selections (conj @selections [label value on-deselect]))))
+                                               (let [selection [label value on-deselect on-select]]
+                                                 (manage-multi-select-fn selections selection disable-multi-valued-input?))
                                                (reset! search nil))))
                    :on-change    #(do (reset! search (input-value %))
                                       (reset! filtered-options (filter (fn [option]
@@ -423,18 +423,10 @@
                                      options
                                      @filtered-options)]
            ^{:key label}
-           (let [selection [label value on-deselect]]
+           (let [selection [label value on-deselect on-select]]
              [multi-select-option {:selected? (contains? @selections selection)
                                    :color-tag color-tag
                                    :label     label
-                                   :on-click  #(do (if (contains? @selections selection)
-                                                     (do
-                                                       (reset! selections (disj @selections selection))
-                                                       (when on-deselect (on-deselect value)))
-                                                     (if disable-multi-valued-input?
-                                                       (reset! selections (into (sorted-set) [selection]))
-                                                       (do
-                                                         (reset! selections (conj @selections selection))
-                                                         (when on-select
-                                                           (on-select value)))))
-                                                   (reset! search nil))}])))])]))
+                                   :on-click  #(do
+                                                 (manage-multi-select-fn selections selection disable-multi-valued-input?)
+                                                 (reset! search nil))}])))])]))


### PR DESCRIPTION
## Purpose

## Related Issues
Closes BHP1-1143

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open surface+contain worksheet in guided mode
2. Select Outputs:
- Fire Behavior > Direction Mode > Heading
- Fire Behavior > Surface Fire > Rate of Spread

3. Navigate to Inputs > Fuel Model
4. Ensure Fuel Model updates stick on refresh
5. Navigate to Inputs > Suppression and select Contain Mode > "Calculate Minimum Production Rate Only"
6. Navigate to Inputs > Fuel Model
7. Ensure Fuel Model updates stick on refresh
6. Repeat steps 1 - 5 for standard workflow (make sure to test on click and on keypress (i.e. enter) behaviors)

## Screenshots