### PR TITLE
[BHP1-1391] Crown Spot - Enable Flame Length only for Active Crown

### DIFF
--- a/development/migrations/2025_10_02_spot_enable_flame_length_only_active_crown.clj
+++ b/development/migrations/2025_10_02_spot_enable_flame_length_only_active_crown.clj
@@ -1,0 +1,48 @@
+(ns migrations.2025-10-02-spot-enable-flame-length-only-active-crown
+  (:require [schema-migrate.interface :refer [bp] :as sm]
+            [datomic.api :as d]
+            [behave-cms.store :refer [default-conn]]
+            [behave-cms.server :as cms]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def spot-fire-behavior-input (sm/t-key->entity (d/db conn) "behaveplus:crown:input:spotting:fire_behavior"))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def active-crowning-max-spotting-distance-gv-uuid (sm/t-key->uuid (d/db conn) "behaveplus:crown:output:spotting_active_crown_fire:maximum_spotting_distance:maximum_spotting_distance"))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def new-conditionals-payload
+  [{:db/id              (:db/id spot-fire-behavior-input)
+    :group/conditionals [(sm/->conditional conn
+                                           {:ttype               :group-variable
+                                            :operator            :equal
+                                            :values              "true"
+                                            :group-variable-uuid active-crowning-max-spotting-distance-gv-uuid})]}])
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (def tx-data @(d/transact conn new-conditionals-payload)))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn tx-data))


### PR DESCRIPTION
## Purpose
EOM

## Related Issues
Closes BHP1-1391

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Run migration `migrations.2025-10-02-spot-enable-flame-length-only-active-crown` and sync
2. Start a Surface & Crown run
3. Select Spot > Max Spotting Distance > Active Crown Fire
4. Go to Inputs
4. Verify that the Spot > Fire Behavior group and the subsequent Flame Length input are shown
2. Start a new Surface & Crown run
5. Select Spot > Max Spotting Distance > Torching Trees
4. Ensure the Spot > Fire Behavior group and the subsequent Flame Length input are hidden
2. Start a new Surface & Crown run
5. Select Fire Behavior > Rate of Spread
3. Select Spot > Max Spotting Distance > Active Crown Fire
4. Ensure the Spot > Fire Behavior group and the subsequent Flame Length input are hidden

## Screenshots

<!-- Message of single commit: -->