### PR TITLE
[BHP1-1441] Support Three Multi Valued Inputs in Matrices

### DIFF
--- a/bases/behave_components/resources/public/css/styles.css
+++ b/bases/behave_components/resources/public/css/styles.css
@@ -1970,6 +1970,13 @@ p {
   background-color: var(--medblue-3);
 }
 
+.table__sub-title {
+  border: 1px solid var(--lightblue-5);
+  text-align: center;
+  color: var(--white);
+  background-color: var(--darkblue-2);
+}
+
 .table-cell {
   padding: 10px;
   border: 1px solid var(--lightblue-5);

--- a/bases/behave_components/src/cljs/behave/components/matrix_table.cljs
+++ b/bases/behave_components/src/cljs/behave/components/matrix_table.cljs
@@ -1,10 +1,13 @@
 (ns behave.components.matrix-table
   (:require [behave.stories.utils :refer [->params]]))
 
-(defn- table-header [title rows-label cols-label header-names]
+(defn- table-header [title rows-label cols-label header-names & [sub-title]]
   [:thead.table-header
    [:tr.table__title
     [:th {:col-span (inc (count header-names))} title]]
+   (when sub-title
+     [:tr.table__sub-title
+      [:th {:col-span (inc (count header-names))} sub-title]])
    (when (and rows-label cols-label)
      [:tr
       [:th.table-header__header {:col-span 1 :scope "row"} rows-label]
@@ -14,13 +17,13 @@
           [:th.table-header__header {:scope "col"} header-name])
         (conj [:th.table-header__header {:scope "col"}]))]])
 
-(defn matrix-table [{:keys [title column-headers row-headers data rows-label cols-label]}]
+(defn matrix-table [{:keys [title sub-title column-headers row-headers data rows-label cols-label]}]
   (let [column-headers      (->params column-headers)
         row-headers         (->params row-headers)
         data                (->params data)
         column-header-names (map :name column-headers)]
     [:table.table
-     [table-header title rows-label cols-label column-header-names]
+     [table-header title rows-label cols-label column-header-names sub-title]
      [:tbody.table__body
       (for [row-header row-headers
             :let       [i    (:key row-header)

--- a/bases/behave_components/src/cljs/behave/stories/matrix_table_stories.cljs
+++ b/bases/behave_components/src/cljs/behave/stories/matrix_table_stories.cljs
@@ -10,25 +10,26 @@
 (defn template [& [args]]
   (->default {:component matrix-table
               :args      (merge {:title          "Matrix Title"
+                                 :sub-title      "Matrix Sub Title (Optional)"
                                  :column-headers [{:name "Column 1" :key :column1}
                                                   {:name "Column 2" :key :column2}
                                                   {:name "Column 3" :key :column3}]
 
-                                 :row-headers    [{:name "Row 1" :key :row1}
-                                                  {:name "Row 2" :key :row2}
-                                                  {:name "Row 3" :key :row3}]
+                                 :row-headers [{:name "Row 1" :key :row1}
+                                               {:name "Row 2" :key :row2}
+                                               {:name "Row 3" :key :row3}]
 
-                                 :data           {[:row1 :column1] 1
-                                                  [:row1 :column2] 2
-                                                  [:row1 :column3] 3
+                                 :data {[:row1 :column1] 1
+                                        [:row1 :column2] 2
+                                        [:row1 :column3] 3
 
-                                                  [:row2 :column1] 4
-                                                  [:row2 :column2] 5
-                                                  [:row2 :column3] 6
+                                        [:row2 :column1] 4
+                                        [:row2 :column2] 5
+                                        [:row2 :column3] 6
 
-                                                  [:row3 :column1] 7
-                                                  [:row3 :column2] 8
-                                                  [:row3 :column3] 9}}
+                                        [:row3 :column1] 7
+                                        [:row3 :column2] 8
+                                        [:row3 :column3] 9}}
                                 args)}))
 
 (def ^:export Default (template))

--- a/bases/behave_components/src/cljs/behave/stories/matrix_table_stories.cljs
+++ b/bases/behave_components/src/cljs/behave/stories/matrix_table_stories.cljs
@@ -14,22 +14,20 @@
                                  :column-headers [{:name "Column 1" :key :column1}
                                                   {:name "Column 2" :key :column2}
                                                   {:name "Column 3" :key :column3}]
+                                 :row-headers    [{:name "Row 1" :key :row1}
+                                                  {:name "Row 2" :key :row2}
+                                                  {:name "Row 3" :key :row3}]
+                                 :data           {[:row1 :column1] 1
+                                                  [:row1 :column2] 2
+                                                  [:row1 :column3] 3
 
-                                 :row-headers [{:name "Row 1" :key :row1}
-                                               {:name "Row 2" :key :row2}
-                                               {:name "Row 3" :key :row3}]
+                                                  [:row2 :column1] 4
+                                                  [:row2 :column2] 5
+                                                  [:row2 :column3] 6
 
-                                 :data {[:row1 :column1] 1
-                                        [:row1 :column2] 2
-                                        [:row1 :column3] 3
-
-                                        [:row2 :column1] 4
-                                        [:row2 :column2] 5
-                                        [:row2 :column3] 6
-
-                                        [:row3 :column1] 7
-                                        [:row3 :column2] 8
-                                        [:row3 :column3] 9}}
+                                                  [:row3 :column1] 7
+                                                  [:row3 :column2] 8
+                                                  [:row3 :column3] 9}}
                                 args)}))
 
 (def ^:export Default (template))
@@ -38,11 +36,9 @@
                                 :column-headers [{:name "0" :key 0}
                                                  {:name "1" :key 1}
                                                  {:name "2" :key 2}]
-
                                 :row-headers    [{:name "0" :key 0}
                                                  {:name "1" :key 1}
                                                  {:name "2" :key 2}]
-
                                 :data           {[0 0] 1
                                                  [0 1] 2
                                                  [0 2] 3

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -145,8 +145,15 @@
 
 (defmethod construct-result-matrices 2
   [{:keys [sub-title ws-uuid process-map-units? multi-valued-inputs formatters output-entities table-setting-filters]}]
-  (let [[row-name row-units row-gv-uuid row-values] (first multi-valued-inputs)
-        [col-name col-units col-gv-uuid col-values] (second multi-valued-inputs)
+  (let [graph-settings                              @(subscribe [:worksheet/graph-settings ws-uuid])
+        x-axis-group-variable-uuid                  (:graph-settings/x-axis-group-variable-uuid graph-settings)
+        z-axis-group-variable-uuid                  (:graph-settings/z-axis-group-variable-uuid graph-settings)
+        [row-name row-units row-gv-uuid row-values] (->> multi-valued-inputs
+                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid x-axis-group-variable-uuid)))
+                                                         first)
+        [col-name col-units col-gv-uuid col-values] (->> multi-valued-inputs
+                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid z-axis-group-variable-uuid)))
+                                                         first)
         map-units-settings-entity                   @(subscribe [:worksheet/map-units-settings-entity ws-uuid])
         map-units                                   (:map-units-settings/units map-units-settings-entity)
         map-rep-frac                                (:map-units-settings/map-rep-fraction map-units-settings-entity)

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -6,6 +6,10 @@
             [goog.string :as gstring]
             [re-frame.core :refer [subscribe]]))
 
+;;==============================================================================
+;; Helpers
+;;==============================================================================
+
 (defn- shade-cell-value? [table-setting-filters output-gv-uuid value]
   (let [[_ mmin mmax enabled?] (first (filter
                                        (fn [[gv-uuid]]
@@ -99,6 +103,10 @@
    {}
    matrix-data-raw))
 
+;;==============================================================================
+;; construct-result-matrices
+;;==============================================================================
+
 (defmulti construct-result-matrices
   "Constructs Result matrices based on how many multi-valued inputs there are"
   (fn [{:keys [multi-valued-inputs]}]
@@ -113,7 +121,7 @@
                         (count multi-valued-inputs))])
 
 (defmethod construct-result-matrices 0
-  [{:keys [ws-uuid process-map-units? output-entities formatters title]}]
+  [{:keys [ws-uuid process-map-units? output-entities formatters]}]
   (let [map-units-settings-entity @(subscribe [:worksheet/map-units-settings-entity ws-uuid])
         map-units                 (:map-units-settings/units map-units-settings-entity)
         map-rep-frac              (:map-units-settings/map-rep-fraction map-units-settings-entity)
@@ -307,6 +315,10 @@
           :formatters            formatters
           :table-setting-filters table-setting-filters}]])]))
 
+;;==============================================================================
+;; View for Result Matrices
+;;==============================================================================
+
 (defn result-matrices [ws-uuid]
   (let [directions                      @(subscribe [:worksheet/output-directions ws-uuid])
         map-units-settings-entity       @(subscribe [:worksheet/map-units-settings-entity ws-uuid])
@@ -325,8 +337,7 @@
                                              (sort-by #(.indexOf gv-order %)))
         non-directional-output-gv-uuids (remove #(contains? directional-uuids %) all-output-gv-uuids)
         directional-gv-uuids            (filter #(contains? directional-uuids %) all-output-gv-uuids)
-        multi-valued-inputs             @(subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
-        results-label                   @(<t (bp "results"))]
+        multi-valued-inputs             @(subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])]
     (when (seq all-output-gv-uuids)
       [:div.wizard-results
        (when (seq directional-gv-uuids)
@@ -351,7 +362,7 @@
                formatters      @(subscribe [:worksheet/result-table-formatters non-directional-output-gv-uuids])]
            [construct-result-matrices
             {:ws-uuid               ws-uuid
-             :title                 results-label
+             :title                 @(<t (bp "results"))
              :process-map-units?    (fn [v-uuid] (and map-units-enabled? (map-unit-convertible-variables v-uuid)))
              :multi-valued-inputs   multi-valued-inputs
              :output-gv-uuids       non-directional-output-gv-uuids

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -222,10 +222,10 @@
         x-axis-gv-uuid                              (:graph-settings/x-axis-group-variable-uuid graph-settings)
         z-axis-gv-uuid                              (:graph-settings/z-axis-group-variable-uuid graph-settings)
         [row-name row-units row-gv-uuid row-values] (->> multi-valued-inputs
-                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid x-axis-gv-uuid)))
+                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid z-axis-gv-uuid)))
                                                          first)
         [col-name col-units col-gv-uuid col-values] (->> multi-valued-inputs
-                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid z-axis-gv-uuid)))
+                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid x-axis-gv-uuid)))
                                                          first)
         {:keys [units rep-fraction]}                (fetch-map-units-settings ws-uuid)
         input-formatters                            @(subscribe [:worksheet/result-table-formatters [row-gv-uuid col-gv-uuid]])

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -1,10 +1,10 @@
 (ns behave.components.results.matrices
-  (:require [behave.components.core  :as c]
-            [behave.translate        :refer [<t bp]]
+  (:require [behave.components.core :as c]
+            [behave.translate :refer [<t bp]]
             [behave.units-conversion :refer [to-map-units]]
-            [clojure.string          :as str]
-            [goog.string             :as gstring]
-            [re-frame.core           :refer [subscribe]]))
+            [clojure.string :as str]
+            [goog.string :as gstring]
+            [re-frame.core :refer [subscribe]]))
 
 (defn- shade-cell-value? [table-setting-filters output-gv-uuid value]
   (let [[_ mmin mmax enabled?] (first (filter
@@ -13,12 +13,94 @@
                                        table-setting-filters))]
     (and enabled? mmin mmax (not (<= mmin value mmax)))))
 
-(defn- header-label  [label units]
+(defn- header-label [label units]
   (if (seq units)
     (gstring/format "%s (%s)" label units)
     (gstring/format "%s" label)))
 
+(defn- fetch-map-units-settings [ws-uuid]
+  (let [entity @(subscribe [:worksheet/map-units-settings-entity ws-uuid])]
+    {:units        (:map-units-settings/units entity)
+     :rep-fraction (:map-units-settings/map-rep-fraction entity)}))
+
+(defn- format-matrix-cell [value formatter shaded?]
+  [:div {:class (cond-> ["result-matrix-cell-value"]
+                  shaded? (conj "table-cell__shaded"))}
+   (if (neg? value)
+     "-"
+     (formatter value))])
+
+(defn- convert-to-map-units [value units map-units map-rep-frac]
+  (to-map-units value units map-units map-rep-frac))
+
+(defn- map-units-column-key [gv-uuid]
+  (str gv-uuid "-map-units"))
+
+(defn- fetch-matrix-data-2d
+  [{:keys [ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-gv-uuid submatrix-gv-uuid submatrix-value]}]
+  (if (and submatrix-value submatrix-gv-uuid)
+    @(subscribe [:print/matrix-table-three-multi-valued-inputs
+                 {:ws-uuid           ws-uuid
+                  :row-gv-uuid       row-gv-uuid
+                  :row-values        row-values
+                  :col-gv-uuid       col-gv-uuid
+                  :col-values        col-values
+                  :output-gv-uuid    output-gv-uuid
+                  :submatrix-gv-uuid submatrix-gv-uuid
+                  :submatrix-value   submatrix-value}])
+    @(subscribe [:print/matrix-table-two-multi-valued-inputs
+                 {:ws-uuid        ws-uuid
+                  :row-gv-uuid    row-gv-uuid
+                  :row-values     row-values
+                  :col-gv-uuid    col-gv-uuid
+                  :col-values     col-values
+                  :output-gv-uuid output-gv-uuid}])))
+
+(defn- compute-shade-set-2d
+  [{:keys [ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-entities table-setting-filters submatrix-gv-uuid submatrix-value]}]
+  (reduce (fn [acc {output-gv-uuid :bp/uuid}]
+            (let [matrix-data (fetch-matrix-data-2d {:ws-uuid           ws-uuid
+                                                     :row-gv-uuid       row-gv-uuid
+                                                     :row-values        row-values
+                                                     :col-gv-uuid       col-gv-uuid
+                                                     :col-values        col-values
+                                                     :output-gv-uuid    output-gv-uuid
+                                                     :submatrix-gv-uuid submatrix-gv-uuid
+                                                     :submatrix-value   submatrix-value})]
+              (into acc
+                    (reduce-kv
+                     (fn [acc [row col] value]
+                       (cond-> acc
+                         (shade-cell-value? table-setting-filters output-gv-uuid value)
+                         (conj [row col])))
+                     #{}
+                     matrix-data))))
+          #{}
+          output-entities))
+
+(defn- build-matrix-data
+  [matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn shade-set]
+  (reduce-kv
+   (fn [acc [row col] value]
+     (let [shaded? (contains? shade-set [row col])]
+       (assoc acc [(row-fmt-fn row) (col-fmt-fn col)]
+              (format-matrix-cell value output-fmt-fn shaded?))))
+   {}
+   matrix-data-raw))
+
+(defn- build-matrix-data-with-map-units
+  [{:keys [matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn output-units map-units map-rep-frac shade-set]}]
+  (reduce-kv
+   (fn [acc [row col] value]
+     (let [shaded?         (contains? shade-set [row col])
+           converted-value (convert-to-map-units value output-units map-units map-rep-frac)]
+       (assoc acc [(row-fmt-fn row) (col-fmt-fn col)]
+              (format-matrix-cell converted-value output-fmt-fn shaded?))))
+   {}
+   matrix-data-raw))
+
 (defmulti construct-result-matrices
+  "Constructs Result matrices based on how many multi-valued inputs there are"
   (fn [{:keys [multi-valued-inputs]}]
     (let [multi-valued-inputs-count (count multi-valued-inputs)]
       (if (<= 0 multi-valued-inputs-count 3)
@@ -37,9 +119,7 @@
         map-rep-frac              (:map-units-settings/map-rep-fraction map-units-settings-entity)
         rows                      (reduce (fn [acc {output-gv-uuid :bp/uuid
                                                     units          :units}]
-                                            (let [value    @(subscribe [:worksheet/first-row-results-gv-uuid->value
-                                                                        ws-uuid
-                                                                        output-gv-uuid])
+                                            (let [value    @(subscribe [:worksheet/first-row-results-gv-uuid->value ws-uuid output-gv-uuid])
                                                   fmt-fn   (get formatters output-gv-uuid identity)
                                                   var-name @(subscribe [:wizard/gv-uuid->resolve-result-variable-name output-gv-uuid])]
                                               (cond-> acc
@@ -53,10 +133,7 @@
                                                 (conj {:output (gstring/format @(<t (bp "s_map_units")) var-name)
                                                        :value  (if (pos? value)
                                                                  (-> value
-                                                                     (to-map-units
-                                                                      units
-                                                                      map-units
-                                                                      map-rep-frac)
+                                                                     (to-map-units units map-units map-rep-frac)
                                                                      fmt-fn)
                                                                  "-")
                                                        :units  map-units}))))
@@ -75,65 +152,53 @@
   (let [[multi-var-name
          multi-var-units
          multi-var-gv-uuid
-         multi-var-values]        (first multi-valued-inputs)
-        input-fmt-fn              (get @(subscribe [:worksheet/result-table-formatters [multi-var-gv-uuid]]) multi-var-gv-uuid)
-        matrix-data-raw           @(subscribe [:worksheet/matrix-table-data-single-multi-valued-input
-                                               ws-uuid
-                                               multi-var-gv-uuid
-                                               multi-var-values
-                                               (map :bp/uuid output-entities)])
-        rows-to-shade-set         (reduce-kv (fn [acc [row col-uuid] v]
-                                               (cond-> acc
-                                                 (shade-cell-value? table-setting-filters col-uuid v)
-                                                 (conj row)))
-                                             #{}
-                                             matrix-data-raw)
-        matrix-data-formatted     (reduce-kv (fn [acc [row col-uuid] v]
-                                               (let [fmt-fn (get formatters col-uuid identity)]
-                                                 (assoc acc [(input-fmt-fn row) col-uuid]
-                                                        [:div {:class ["result-matrix-cell-value"
-                                                                       (when (contains? rows-to-shade-set row)
-                                                                         "table-cell__shaded")]}
-                                                         (if (neg? v)
-                                                           "-"
-                                                           (fmt-fn v))])))
-                                             {}
-                                             matrix-data-raw)
-        map-units-settings-entity @(subscribe [:worksheet/map-units-settings-entity ws-uuid])
-        map-units                 (:map-units-settings/units map-units-settings-entity)
-        map-rep-frac              (:map-units-settings/map-rep-fraction map-units-settings-entity)
-        column-headers            (reduce (fn insert-map-units-columns [acc {output-gv-uuid :bp/uuid
-                                                                             output-units   :units}]
-                                            (let [output-name @(subscribe [:wizard/gv-uuid->resolve-result-variable-name output-gv-uuid])]
-                                              (cond-> acc
-                                                (process-map-units? output-gv-uuid)
-                                                (conj {:name (gstring/format @(<t (bp "s_map_units_(s)"))
-                                                                             output-name
-                                                                             map-units)
-                                                       :key  (str output-gv-uuid "-map-units")})
-                                                :always (conj {:name (header-label output-name output-units)
-                                                               :key  output-gv-uuid}))))
-                                          []
-                                          output-entities)
-        row-headers               (map (fn [value] {:name (input-fmt-fn value) :key (input-fmt-fn value)}) multi-var-values)
-        final-data                (reduce (fn insert-map-units-values [acc [[row col] value]]
-                                            (let [fmt-fn (get formatters col identity)]
-                                              (cond-> acc
-                                                (process-map-units? col)
-                                                (assoc [(input-fmt-fn row) (str col "-map-units")]
-                                                       [:div {:class ["result-matrix-cell-value"
-                                                                      (when (contains? rows-to-shade-set col)
-                                                                        "table-cell__shaded")]}
-                                                        (if (neg? value)
-                                                          "-"
-                                                          (-> value
-                                                              (to-map-units
-                                                               (get units-lookup col)
-                                                               map-units
-                                                               map-rep-frac)
-                                                              fmt-fn))]))))
-                                          matrix-data-formatted
-                                          matrix-data-raw)]
+         multi-var-values]           (first multi-valued-inputs)
+        input-fmt-fn                 (get @(subscribe [:worksheet/result-table-formatters [multi-var-gv-uuid]]) multi-var-gv-uuid)
+        matrix-data-raw              @(subscribe [:worksheet/matrix-table-data-single-multi-valued-input
+                                                  ws-uuid
+                                                  multi-var-gv-uuid
+                                                  multi-var-values
+                                                  (map :bp/uuid output-entities)])
+        rows-to-shade-set            (reduce-kv (fn [acc [row col-uuid] v]
+                                                  (cond-> acc
+                                                    (shade-cell-value? table-setting-filters col-uuid v)
+                                                    (conj row)))
+                                                #{}
+                                                matrix-data-raw)
+        matrix-data-formatted        (reduce-kv (fn [acc [row col-uuid] v]
+                                                  (let [fmt-fn  (get formatters col-uuid identity)
+                                                        shaded? (contains? rows-to-shade-set row)]
+                                                    (assoc acc [(input-fmt-fn row) col-uuid]
+                                                           (format-matrix-cell v fmt-fn shaded?))))
+                                                {}
+                                                matrix-data-raw)
+        {:keys [units rep-fraction]} (fetch-map-units-settings ws-uuid)
+        column-headers               (reduce (fn insert-map-units-columns [acc {output-gv-uuid :bp/uuid
+                                                                                output-units   :units}]
+                                               (let [output-name @(subscribe [:wizard/gv-uuid->resolve-result-variable-name output-gv-uuid])]
+                                                 (cond-> acc
+                                                   (process-map-units? output-gv-uuid)
+                                                   (conj {:name (gstring/format @(<t (bp "s_map_units_(s)"))
+                                                                                output-name
+                                                                                units)
+                                                          :key  (map-units-column-key output-gv-uuid)})
+                                                   :always (conj {:name (header-label output-name output-units)
+                                                                  :key  output-gv-uuid}))))
+                                             []
+                                             output-entities)
+        row-headers                  (map (fn [value] {:name (input-fmt-fn value) :key (input-fmt-fn value)}) multi-var-values)
+        final-data                   (reduce (fn insert-map-units-values [acc [[row col] value]]
+                                               (let [fmt-fn  (get formatters col identity)
+                                                     shaded? (contains? rows-to-shade-set col)]
+                                                 (cond-> acc
+                                                   (process-map-units? col)
+                                                   (assoc [(input-fmt-fn row) (map-units-column-key col)]
+                                                          (format-matrix-cell
+                                                           (convert-to-map-units value (get units-lookup col) units rep-fraction)
+                                                           fmt-fn
+                                                           shaded?)))))
+                                             matrix-data-formatted
+                                             matrix-data-raw)]
     [:div.print__result-table
      (c/matrix-table {:title          title
                       :rows-label     (header-label multi-var-name multi-var-units)
@@ -144,109 +209,65 @@
 
 (defmethod construct-result-matrices 2
   [{:keys [ws-uuid process-map-units? multi-valued-inputs formatters output-entities table-setting-filters
-           sub-title
-           submatrix-value
-           submatrix-gv-uuid]}]
+           sub-title submatrix-value submatrix-gv-uuid]}]
   (let [graph-settings                              @(subscribe [:worksheet/graph-settings ws-uuid])
-        x-axis-group-variable-uuid                  (:graph-settings/x-axis-group-variable-uuid graph-settings)
-        z-axis-group-variable-uuid                  (:graph-settings/z-axis-group-variable-uuid graph-settings)
+        x-axis-gv-uuid                              (:graph-settings/x-axis-group-variable-uuid graph-settings)
+        z-axis-gv-uuid                              (:graph-settings/z-axis-group-variable-uuid graph-settings)
         [row-name row-units row-gv-uuid row-values] (->> multi-valued-inputs
-                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid x-axis-group-variable-uuid)))
+                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid x-axis-gv-uuid)))
                                                          first)
         [col-name col-units col-gv-uuid col-values] (->> multi-valued-inputs
-                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid z-axis-group-variable-uuid)))
+                                                         (filter (fn [[_ _ gv-uuid]] (= gv-uuid z-axis-gv-uuid)))
                                                          first)
-        map-units-settings-entity                   @(subscribe [:worksheet/map-units-settings-entity ws-uuid])
-        map-units                                   (:map-units-settings/units map-units-settings-entity)
-        map-rep-frac                                (:map-units-settings/map-rep-fraction map-units-settings-entity)
+        {:keys [units rep-fraction]}                (fetch-map-units-settings ws-uuid)
         input-formatters                            @(subscribe [:worksheet/result-table-formatters [row-gv-uuid col-gv-uuid]])
-        row-cols-to-shade-set                       (reduce (fn [acc {output-gv-uuid :bp/uuid}]
-                                                              (let [matrix-data-raw (if (and submatrix-value submatrix-gv-uuid)
-                                                                                      @(subscribe [:print/matrix-table-three-multi-valued-inputs ws-uuid
-                                                                                                   row-gv-uuid
-                                                                                                   row-values
-                                                                                                   col-gv-uuid
-                                                                                                   col-values
-                                                                                                   output-gv-uuid
-                                                                                                   submatrix-gv-uuid
-                                                                                                   submatrix-value])
-                                                                                      @(subscribe [:print/matrix-table-two-multi-valued-inputs ws-uuid
-                                                                                                   row-gv-uuid
-                                                                                                   row-values
-                                                                                                   col-gv-uuid
-                                                                                                   col-values
-                                                                                                   output-gv-uuid]))]
-                                                                (into acc
-                                                                      (reduce-kv
-                                                                       (fn [acc [row col] value]
-                                                                         (cond-> acc
-                                                                           (shade-cell-value? table-setting-filters output-gv-uuid value)
-                                                                           (conj [row col])))
-                                                                       #{}
-                                                                       matrix-data-raw))))
-                                                            #{}
-                                                            output-entities)]
+        row-fmt-fn                                  (get input-formatters row-gv-uuid identity)
+        col-fmt-fn                                  (get input-formatters col-gv-uuid identity)
+        shade-set                                   (compute-shade-set-2d {:ws-uuid               ws-uuid
+                                                                           :row-gv-uuid           row-gv-uuid
+                                                                           :row-values            row-values
+                                                                           :col-gv-uuid           col-gv-uuid
+                                                                           :col-values            col-values
+                                                                           :output-entities       output-entities
+                                                                           :table-setting-filters table-setting-filters
+                                                                           :submatrix-gv-uuid     submatrix-gv-uuid
+                                                                           :submatrix-value       submatrix-value})
+        row-headers                                 (map (fn [value] {:name (row-fmt-fn value) :key (row-fmt-fn value)}) row-values)
+        column-headers                              (map (fn [value] {:name (col-fmt-fn value) :key (col-fmt-fn value)}) col-values)]
     [:div.print__construct-result-matrices
-     (for [{output-gv-uuid :bp/uuid
-            output-units   :units} output-entities]
+     (for [{output-gv-uuid :bp/uuid output-units :units} output-entities]
        (let [output-name     @(subscribe [:wizard/gv-uuid->resolve-result-variable-name output-gv-uuid])
              output-fmt-fn   (get formatters output-gv-uuid identity)
-             row-fmt-fn      (get input-formatters row-gv-uuid identity)
-             col-fmt-fn      (get input-formatters col-gv-uuid identity)
-             matrix-data-raw (if (and submatrix-value submatrix-gv-uuid)
-                               @(subscribe [:print/matrix-table-three-multi-valued-inputs ws-uuid
-                                            row-gv-uuid
-                                            row-values
-                                            col-gv-uuid
-                                            col-values
-                                            output-gv-uuid
-                                            submatrix-gv-uuid
-                                            submatrix-value])
-                               @(subscribe [:print/matrix-table-two-multi-valued-inputs ws-uuid
-                                            row-gv-uuid
-                                            row-values
-                                            col-gv-uuid
-                                            col-values
-                                            output-gv-uuid]))
+             matrix-data-raw (fetch-matrix-data-2d {:ws-uuid           ws-uuid
+                                                    :row-gv-uuid       row-gv-uuid
+                                                    :row-values        row-values
+                                                    :col-gv-uuid       col-gv-uuid
+                                                    :col-values        col-values
+                                                    :output-gv-uuid    output-gv-uuid
+                                                    :submatrix-gv-uuid submatrix-gv-uuid
+                                                    :submatrix-value   submatrix-value})
              output-values   (map second matrix-data-raw)]
-         (when (not (every? #(= "-1" %) output-values))
-           (let [matrix-data-formatted (reduce-kv
-                                        (fn [acc [row col] value]
-                                          (assoc acc
-                                                 [(row-fmt-fn row) (col-fmt-fn col)]
-                                                 [:div {:class ["result-matrix-cell-value"
-                                                                (when (contains? row-cols-to-shade-set [row col])
-                                                                  "table-cell__shaded")]}
-                                                  (if (neg? value)
-                                                    "-"
-                                                    (output-fmt-fn value))]))
-                                        {}
-                                        matrix-data-raw)
-                 row-headers           (map (fn [value] {:name (row-fmt-fn value) :key (row-fmt-fn value)}) row-values)
-                 column-headers        (map (fn [value] {:name (col-fmt-fn value) :key (col-fmt-fn value)}) col-values)]
+         (when-not (every? #(= "-1" %) output-values)
+           (let [matrix-data-formatted (build-matrix-data matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn shade-set)]
              [:<>
+              (when (process-map-units? output-gv-uuid)
+                [:div.print__result-table
+                 (let [data (build-matrix-data-with-map-units {:matrix-data-raw matrix-data-raw
+                                                               :row-fmt-fn      row-fmt-fn
+                                                               :col-fmt-fn      col-fmt-fn
+                                                               :output-fmt-fn   output-fmt-fn
+                                                               :output-units    output-units
+                                                               :map-units       units
+                                                               :map-rep-frac    rep-fraction
+                                                               :shade-set       shade-set})]
+                   (c/matrix-table {:title          (gstring/format @(<t (bp "s_map_units_(s)")) output-name units)
+                                    :sub-title      sub-title
+                                    :rows-label     (header-label row-name row-units)
+                                    :cols-label     (header-label col-name col-units)
+                                    :row-headers    row-headers
+                                    :column-headers column-headers
+                                    :data           data}))])
               [:div.print__result-table
-               (when (process-map-units? output-gv-uuid)
-                 [:div.print__result-table
-                  (let [data (reduce-kv (fn [acc [row col] value]
-                                          (assoc acc [(row-fmt-fn row) (col-fmt-fn col)]
-                                                 [:div {:class ["result-matrix-cell-value"
-                                                                (when (contains? row-cols-to-shade-set [row col])
-                                                                  "table-cell__shaded")]}
-                                                  (if (neg? value)
-                                                    "-"
-                                                    (-> value
-                                                        (to-map-units output-units map-units map-rep-frac)
-                                                        output-fmt-fn))]))
-                                        matrix-data-formatted
-                                        matrix-data-raw)]
-                    (c/matrix-table {:title          (gstring/format @(<t (bp "s_map_units_(s)")) output-name map-units)
-                                     :sub-title      sub-title
-                                     :rows-label     (header-label row-name row-units)
-                                     :cols-label     (header-label col-name col-units)
-                                     :row-headers    row-headers
-                                     :column-headers column-headers
-                                     :data           data}))])
                (c/matrix-table {:title          (header-label output-name output-units)
                                 :sub-title      sub-title
                                 :rows-label     (header-label row-name row-units)
@@ -277,8 +298,8 @@
                                    (gstring/format "%s: %s"
                                                    var-name
                                                    @(subscribe [:vms/resolve-enum-translation gv-uuid value])))
-          :submatrix-value value
-          :submatrix-gv-uuid gv-uuid
+          :submatrix-value       value
+          :submatrix-gv-uuid     gv-uuid
           :process-map-units?    process-map-units?
           :multi-valued-inputs   rest-multi-valued-inputs
           :output-entities       output-entities
@@ -297,46 +318,44 @@
         pivot-tables                    @(subscribe [:worksheet/pivot-tables ws-uuid])
         directional-uuids               (set @(subscribe [:vms/directional-group-variable-uuids]))
         pivot-table-uuids               (->> pivot-tables
-                                             (mapcat (fn [pivot-table]
-                                                       @(subscribe [:worksheet/pivot-table-fields (:db/id pivot-table)])))
+                                             (mapcat (fn [pivot-table] @(subscribe [:worksheet/pivot-table-fields (:db/id pivot-table)])))
                                              set)
-        all-output-gv-uuids             (->> (subscribe [:worksheet/output-uuids-conditionally-filtered ws-uuid])
-                                             deref
+        all-output-gv-uuids             (->> @(subscribe [:worksheet/output-uuids-conditionally-filtered ws-uuid])
                                              (remove #(contains? pivot-table-uuids %))
                                              (sort-by #(.indexOf gv-order %)))
         non-directional-output-gv-uuids (remove #(contains? directional-uuids %) all-output-gv-uuids)
-        directional-gv-uuids            (filter #(contains? directional-uuids %) all-output-gv-uuids)]
+        directional-gv-uuids            (filter #(contains? directional-uuids %) all-output-gv-uuids)
+        multi-valued-inputs             @(subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
+        results-label                   @(<t (bp "results"))]
     (when (seq all-output-gv-uuids)
       [:div.wizard-results
        (when (seq directional-gv-uuids)
          (for [direction directions]
-           (let [output-gv-uuids (filter #(deref (subscribe [:vms/group-variable-is-directional? % direction])) directional-gv-uuids)]
+           (let [output-gv-uuids (filter #(deref (subscribe [:vms/group-variable-is-directional? % direction])) directional-gv-uuids)
+                 group-variables (map (fn [gv-uuid] @(subscribe [:wizard/group-variable gv-uuid])) output-gv-uuids)
+                 output-entities (map (fn [gv] (merge gv {:units (get units-lookup (:bp/uuid gv))})) group-variables)
+                 formatters      @(subscribe [:worksheet/result-table-formatters output-gv-uuids])]
              [construct-result-matrices
               {:title                 (str/capitalize (name direction))
                :ws-uuid               ws-uuid
-               :process-map-units?    (fn [v-uuid]
-                                        (and map-units-enabled?
-                                             (map-unit-convertible-variables v-uuid)))
-               :multi-valued-inputs   @(subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
+               :process-map-units?    (fn [v-uuid] (and map-units-enabled? (map-unit-convertible-variables v-uuid)))
+               :multi-valued-inputs   multi-valued-inputs
                :output-gv-uuids       output-gv-uuids
-               :output-entities       (map (fn [gv-uuid]
-                                             (-> @(subscribe [:wizard/group-variable gv-uuid])
-                                                 (merge {:units (get units-lookup gv-uuid)}))) output-gv-uuids)
+               :output-entities       output-entities
                :units-lookup          units-lookup
-               :formatters            @(subscribe [:worksheet/result-table-formatters output-gv-uuids])
+               :formatters            formatters
                :table-setting-filters table-setting-filters}])))
        (when (seq non-directional-output-gv-uuids)
-         [construct-result-matrices
-          {:ws-uuid               ws-uuid
-           :title                 @(<t (bp "results"))
-           :process-map-units?    (fn [v-uuid]
-                                    (and map-units-enabled?
-                                         (map-unit-convertible-variables v-uuid)))
-           :multi-valued-inputs   @(subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
-           :output-gv-uuids       non-directional-output-gv-uuids
-           :output-entities       (map (fn [gv-uuid]
-                                         (-> @(subscribe [:wizard/group-variable gv-uuid])
-                                             (merge {:units (get units-lookup gv-uuid)}))) non-directional-output-gv-uuids)
-           :units-lookup          units-lookup
-           :formatters            @(subscribe [:worksheet/result-table-formatters non-directional-output-gv-uuids])
-           :table-setting-filters table-setting-filters}])])))
+         (let [group-variables (map (fn [gv-uuid] @(subscribe [:wizard/group-variable gv-uuid])) non-directional-output-gv-uuids)
+               output-entities (map (fn [gv] (merge gv {:units (get units-lookup (:bp/uuid gv))})) group-variables)
+               formatters      @(subscribe [:worksheet/result-table-formatters non-directional-output-gv-uuids])]
+           [construct-result-matrices
+            {:ws-uuid               ws-uuid
+             :title                 results-label
+             :process-map-units?    (fn [v-uuid] (and map-units-enabled? (map-unit-convertible-variables v-uuid)))
+             :multi-valued-inputs   multi-valued-inputs
+             :output-gv-uuids       non-directional-output-gv-uuids
+             :output-entities       output-entities
+             :units-lookup          units-lookup
+             :formatters            formatters
+             :table-setting-filters table-setting-filters}]))])))

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -147,7 +147,6 @@
            sub-title
            submatrix-value
            submatrix-gv-uuid]}]
-  (prn "construct Matrix")
   (let [graph-settings                              @(subscribe [:worksheet/graph-settings ws-uuid])
         x-axis-group-variable-uuid                  (:graph-settings/x-axis-group-variable-uuid graph-settings)
         z-axis-group-variable-uuid                  (:graph-settings/z-axis-group-variable-uuid graph-settings)

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -230,15 +230,12 @@
 
 (defmethod construct-result-matrices 3
   [{:keys [ws-uuid process-map-units? multi-valued-inputs formatters output-entities table-setting-filters units-lookup]}]
-  (let [first-multi-value                                                      (first @(subscribe [:worksheet/multi-value-input-uuids ws-uuid]))
-        [v-name units-short-code gv-uuid values :as first-multi-valued-inputs] (->> multi-valued-inputs
-                                                                                    (filter (fn [[_ _ gv-uuid]] (= gv-uuid first-multi-value)))
-                                                                                    first)
-        rest-multi-valued-inputs                                               (filter (fn [[_ _ gv-uuid]]
-                                                                                         (not= gv-uuid first-multi-value))
-                                                                                       multi-valued-inputs)]
-    (prn "gv-uuid:" gv-uuid)
-    (prn "gv-uuid:" first-multi-valued-inputs)
+  (let [graph-settings                             @(subscribe [:worksheet/graph-settings ws-uuid])
+        z2-axis-group-variable-uuid                (:graph-settings/z2-axis-group-variable-uuid graph-settings)
+        [var-name units-short-code gv-uuid values] (->> multi-valued-inputs
+                                                        (filter (fn [[_ _ gv-uuid]] (= gv-uuid z2-axis-group-variable-uuid)))
+                                                        first)
+        rest-multi-valued-inputs                   (filter (fn [[_ _ gv-uuid]] (not= gv-uuid z2-axis-group-variable-uuid)) multi-valued-inputs)]
     [:div.print__result-table
      (for [value values]
        [:div.print__result-table
@@ -247,11 +244,11 @@
           :title                 @(<t (bp "results"))
           :sub-title             (if (not-empty units-short-code)
                                    (gstring/format "%s: %s (%s)"
-                                                   v-name
+                                                   var-name
                                                    @(subscribe [:vms/resolve-enum-translation gv-uuid value])
                                                    units-short-code)
                                    (gstring/format "%s: %s"
-                                                   v-name
+                                                   var-name
                                                    @(subscribe [:vms/resolve-enum-translation gv-uuid value])))
           :process-map-units?    process-map-units?
           :multi-valued-inputs   rest-multi-valued-inputs

--- a/projects/behave/src/cljs/behave/print/subs.cljs
+++ b/projects/behave/src/cljs/behave/print/subs.cljs
@@ -1,9 +1,9 @@
 (ns behave.print.subs
-  (:require [behave.store           :as s]
-            [clojure.string         :as str]
-            [datascript.core        :as d]
-            [re-frame.core          :as rf]
-            [re-posh.core           :as rp]
+  (:require [behave.store :as s]
+            [clojure.string :as str]
+            [datascript.core :as d]
+            [re-frame.core :as rf]
+            [re-posh.core :as rp]
             [string-utils.interface :refer [split-commas-or-spaces]]))
 
 (rf/reg-sub
@@ -26,7 +26,7 @@
  (fn [[_ ws-uuid row-gv-uuid row-values output-gv-uuids]]
    (rf/subscribe [:query
                   '[:find ?i ?j ?value-j
-                    :in $ ?ws-uuid ?row-gv-uuid [?i ... ] [?j ...]
+                    :in $ ?ws-uuid ?row-gv-uuid [?i ...] [?j ...]
                     :where
                     [?w :worksheet/uuid ?ws-uuid]
                     [?w :worksheet/result-table ?rt]
@@ -56,10 +56,10 @@
 
 (rf/reg-sub
  :print/matrix-table-two-multi-valued-inputs
- (fn [_ [_ ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-gv-uuid]]
+ (fn [_ [_ {:keys [ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-gv-uuid]}]]
    (let [table-data (d/q
                      '[:find ?i ?j ?value
-                       :in $ ?ws-uuid ?row-gv-uuid [?i ... ] ?col-gv-uuid [?j ... ] ?output-gv-uuid
+                       :in $ ?ws-uuid ?row-gv-uuid [?i ...] ?col-gv-uuid [?j ...] ?output-gv-uuid
                        :where
                        [?w :worksheet/uuid ?ws-uuid]
                        [?w :worksheet/result-table ?rt]
@@ -94,10 +94,10 @@
 
 (rf/reg-sub
  :print/matrix-table-three-multi-valued-inputs
- (fn [_ [_ ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-gv-uuid  submatrix-gv-uuid submatrix-value]]
+ (fn [_ [_ {:keys [ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-gv-uuid submatrix-gv-uuid submatrix-value]}]]
    (let [table-data (d/q
                      '[:find ?i ?j ?value
-                       :in $ ?ws-uuid ?row-gv-uuid [?i ... ] ?col-gv-uuid [?j ... ] ?output-gv-uuid ?submatrix-gv-uuid ?submatrix-value
+                       :in $ ?ws-uuid ?row-gv-uuid [?i ...] ?col-gv-uuid [?j ...] ?output-gv-uuid ?submatrix-gv-uuid ?submatrix-value
                        :where
                        [?w :worksheet/uuid ?ws-uuid]
                        [?w :worksheet/result-table ?rt]
@@ -159,33 +159,3 @@
              ;;get value
              [?c :result-cell/value ?value]]
     :variables [ws-uuid gv-uuid]}))
-
-(comment
-  (require '[goog.string      :as gstring])
-
-  (def ws-uuid "64f9f2b9-d73d-4240-840e-439f4b3efa6b")
-
-  (rf/subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
-
-  (let [ws-uuid                                     "64f9f2b9-d73d-4240-840e-439f4b3efa6b"
-        multi-valued-inputs                         @(rf/subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
-        [row-name row-units row-gv-uuid row-values] (first multi-valued-inputs)
-        [col-name col-units col-gv-uuid col-values] (second multi-valued-inputs)
-        output-uuids                                @(rf/subscribe [:worksheet/output-uuids-filtered ws-uuid])]
-
-    #_(rf/subscribe [:print/matrix-table-two-multi-valued-inputs ws-uuid
-                     row-gv-uuid
-                     (str/split row-values ",")
-                     col-gv-uuid
-                     (str/split col-values ",")
-                     (first output-uuids)])
-    row-gv-uuid
-    (str/split row-values ",")
-    col-gv-uuid
-    (str/split col-values ",")
-    (first output-uuids)
-    )
-
-  (rf/subscribe [:worksheet/output-uuids-filtered ws-uuid])
-
-  )


### PR DESCRIPTION
## Purpose

I also did a bit of refactoring in this ns:

- Moved some logic into helper functions
- Refactored subscriptions to use map arguments
- Subscriptions are now dereferenced in let bindings rather than inline as function arguments

## Related Issues
Closes BHP1-1441

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open this worksheet and navigate to results page:
2. Ensure there are now matrices for the third multi valued input.
3. Go back to inputs and change one of the multi valued inputs into a single input.
4. Rerun and ensure result matrices look as expected and as before.
5. Repeat steps 3-4

## Screenshots