### PR TITLE
[BHP1-1479] Unify app / server mode under `behave.core/-main`

### DIFF
--- a/components/config/src/config/core.clj
+++ b/components/config/src/config/core.clj
@@ -1,6 +1,6 @@
 (ns config.core
-  (:require [clojure.java.io :as io]
-            [clojure.edn     :as edn]))
+  (:require [clojure.edn     :as edn]
+            [clojure.java.io :as io]))
 
 ;;; Private vars
 
@@ -32,6 +32,11 @@
   ([new-config-file]
    (reset! config-file new-config-file)
    (reset! config-cache (read-config @config-file))))
+
+(defn merge-config!
+  "Deep-merges `overrides` into the cached config."
+  [overrides]
+  (swap! config-cache (fn [c] (merge-with merge (or c (read-config @config-file)) overrides))))
 
 (defn get-config
   "Retrieves the key `k` from the config file.

--- a/components/config/src/config/interface.clj
+++ b/components/config/src/config/interface.clj
@@ -2,11 +2,15 @@
   (:require [config.core :as core]))
 
 (def ^{:argslist '([] [config-file])
-       :doc "Re/loads a configuration file. Defaults to the last loaded file,
-            or config.edn."}
+       :doc
+       "Re/loads a configuration file. Defaults to the last loaded file, or config.edn."}
   load-config core/load-config)
 
-(def ^{:argslist '([& ks])
+(def ^{:argslist '([overrides])
+       :doc      "Deep-merges `overrides` into the cached config."}
+  merge-config! core/merge-config!)
+
+(def ^{:argslist                                                                '([& ks])
        :doc
        "Retrieves the key `k` from the config file. Can also be called with the
        multiple keys leading to a config.
@@ -21,6 +25,5 @@
        ```clojure
        (get-config :mail) ; => {:host \"google.com\" :port 543}
        (get-config :mail :host) ; => \"google.com\"
-       ```"
-       }
+       ```"}
   get-config core/get-config)

--- a/components/jcef/src/jcef/setup.clj
+++ b/components/jcef/src/jcef/setup.clj
@@ -35,13 +35,18 @@
 
 (defn jcef-builder
   "Produces a `CEFAppBuilder` with the installation
-   directory set according to the System OS."
+   directory set according to the System OS.
+
+   Skips installation (i.e. no Chrome/CEF download) whenever an
+   install directory is already present on disk. In packaged
+   Conveyor mode (`app.dir` is set) installation is always skipped
+   because the bundle ships with the app."
   []
   (let [app-dir  (System/getProperty "app.dir")
-        jcef-dir (get-jcef-dir)]
-    (if (nil? app-dir)
-      (doto (CefAppBuilder.)
-        (.setInstallDir jcef-dir))
-      (doto (CefAppBuilder.)
-        (.setInstallDir jcef-dir)
-        (.setSkipInstallation true)))))
+        jcef-dir (get-jcef-dir)
+        builder  (doto (CefAppBuilder.)
+                   (.setInstallDir jcef-dir))]
+    (when (or (some? app-dir)
+              (.exists jcef-dir))
+      (.setSkipInstallation builder true))
+    builder))

--- a/projects/behave/src/clj/behave/core.clj
+++ b/projects/behave/src/clj/behave/core.clj
@@ -7,8 +7,6 @@
             [clojure.java.io      :as io]
             [config.interface     :refer [get-config]]
             [file-utils.interface :refer [os-type app-data-dir]]
-            [jcef.core            :refer [show-dev-tools!]]
-            [jcef.interface       :refer [create-cef-app! custom-request-handler show-loader!]]
             [logging.interface    :as l :refer [log-str]]))
 
 ;;; Logging
@@ -72,26 +70,31 @@
 (defn- start-cef!
   "Start the app in JCEF desktop mode."
   []
-  (let [loader          (show-loader! "Behave7" (io/resource "public/images/android-chrome-512x512.png"))
-        mode            (get-config :server :mode)
-        http-port       (or (get-config :server :http-port) 8080)
-        org-name        (get-config :site :org-name)
-        app-name        (get-config :site :app-name)
-        my-app-data-dir (app-data-dir org-name app-name)
-        log-config      (if (= "prod" mode)
-                          (assoc (get-config :logging) :log-dir (str (io/file my-app-data-dir "logs")))
-                          (get-config :logging))
-        db-config       (if (= "prod" mode)
-                          (assoc-in (get-config :database :config)
-                                    [:store :path]
-                                    (str (io/file my-app-data-dir "db.sqlite")))
-                          (get-config :database :config))
-        cache-path      (str (io/file my-app-data-dir ".cache"))
-        request-handler (custom-request-handler
-                         {:protocol     "http"
-                          :authority    (format "localhost:%s" http-port)
-                          :resource-dir "public"
-                          :ring-handler (create-cef-handler-stack)})]
+  ;; Lazy-require jcef so server mode never loads jcef namespaces or
+  ;; org.cef.* classes. Only this code path pulls in the native bundle.
+  (let [show-loader!           (requiring-resolve 'jcef.interface/show-loader!)
+        create-cef-app!        (requiring-resolve 'jcef.interface/create-cef-app!)
+        custom-request-handler (requiring-resolve 'jcef.interface/custom-request-handler)
+        loader                 (show-loader! "Behave7" (io/resource "public/images/android-chrome-512x512.png"))
+        mode                   (get-config :server :mode)
+        http-port              (or (get-config :server :http-port) 8080)
+        org-name               (get-config :site :org-name)
+        app-name               (get-config :site :app-name)
+        my-app-data-dir        (app-data-dir org-name app-name)
+        log-config             (if (= "prod" mode)
+                                 (assoc (get-config :logging) :log-dir (str (io/file my-app-data-dir "logs")))
+                                 (get-config :logging))
+        db-config              (if (= "prod" mode)
+                                 (assoc-in (get-config :database :config)
+                                           [:store :path]
+                                           (str (io/file my-app-data-dir "db.sqlite")))
+                                 (get-config :database :config))
+        cache-path             (str (io/file my-app-data-dir ".cache"))
+        request-handler        (custom-request-handler
+                                {:protocol     "http"
+                                 :authority    (format "localhost:%s" http-port)
+                                 :resource-dir "public"
+                                 :ring-handler (create-cef-handler-stack)})]
 
     (start-logging! log-config)
     (server/init-db! db-config)
@@ -118,7 +121,14 @@
       (server/init-config!)
       (server/enrich-config!)
       (start-cef!))
-    (server/start-server!)))
+    (do
+      (server/start-server!)
+      ;; `server.core/start-server!` runs Jetty with `:join? false`, and
+      ;; neither `vms-sync!` nor `watch-kill-signal!` blocks — so without
+      ;; parking here the main thread would return and the JVM would exit
+      ;; before any request could be served. Block until the process is
+      ;; killed (Ctrl-C / SIGTERM).
+      @(promise))))
 
 (comment
   (-main)

--- a/projects/behave/src/clj/behave/core.clj
+++ b/projects/behave/src/clj/behave/core.clj
@@ -1,12 +1,12 @@
 (ns behave.core
   (:gen-class)
-  (:import [javax.swing JFrame SwingUtilities UIManager]
-           [javax.imageio ImageIO])
-  (:require [clojure.java.io      :as io]
-            [behave.handlers      :refer [create-cef-handler-stack]]
-            [behave.server        :refer [init-config! init-db!]]
-            [file-utils.interface :refer [os-type app-data-dir]]
+  (:import [javax.imageio ImageIO]
+           [javax.swing JFrame SwingUtilities UIManager])
+  (:require [behave.handlers      :refer [create-cef-handler-stack]]
+            [behave.server        :as server]
+            [clojure.java.io      :as io]
             [config.interface     :refer [get-config]]
+            [file-utils.interface :refer [os-type app-data-dir]]
             [jcef.core            :refer [show-dev-tools!]]
             [jcef.interface       :refer [create-cef-app! custom-request-handler show-loader!]]
             [logging.interface    :as l :refer [log-str]]))
@@ -60,10 +60,18 @@
 
 (defonce ^:private the-app (atom nil))
 
-(defn -main
-  "CEF client start method."
-  [& _args]
-  (init-config!)
+;;; Runtime Detection
+
+(defn- conveyor?
+  "True when running inside a Conveyor-packaged app (app.dir is set)."
+  []
+  (some? (System/getProperty "app.dir")))
+
+;;; Entry Points
+
+(defn- start-cef!
+  "Start the app in JCEF desktop mode."
+  []
   (let [loader          (show-loader! "Behave7" (io/resource "public/images/android-chrome-512x512.png"))
         mode            (get-config :server :mode)
         http-port       (or (get-config :server :http-port) 8080)
@@ -86,23 +94,35 @@
                           :ring-handler (create-cef-handler-stack)})]
 
     (start-logging! log-config)
-    (init-db! db-config)
+    (server/init-db! db-config)
 
     (create-cef-app!
-     {:title           (get-config :site :title)
-      :url             (str "http://localhost:" http-port)
-      :cache-path      cache-path
-      :fullscreen?     true
-      :on-shown        (fn [app & _]
-                         (reset! the-app app)
-                         (.dispose (:frame loader)))
-      :request-handler request-handler
+     {:title                                                (get-config :site :title)
+      :url                                                  (str "http://localhost:" http-port)
+      :cache-path                                           cache-path
+      :fullscreen?                                          true
+      :on-shown                                             (fn [app & _]
+                                                              (reset! the-app app)
+                                                              (.dispose (:frame loader)))
+      :request-handler                                      request-handler
       :on-before-launch
       (fn [{:keys [frame]}]
         (on-before-launch frame (get-config :site :title)))})))
 
+(defn -main
+  "Unified entry point. Detects runtime environment and starts
+   in CEF desktop mode or HTTP server mode."
+  [& _args]
+  (if (conveyor?)
+    (do
+      (server/init-config!)
+      (server/enrich-config!)
+      (start-cef!))
+    (server/start-server!)))
+
 (comment
   (-main)
+  (start-cef!)
   ;; Dev Tools
   @the-app
   (require '[jcef.core :as jc])

--- a/projects/behave/src/clj/behave/handlers.clj
+++ b/projects/behave/src/clj/behave/handlers.clj
@@ -9,7 +9,6 @@
             [bidi.bidi                         :refer [match-route]]
             [clojure.core.async                :refer [<! alts! chan go-loop put! timeout]]
             [clojure.edn                       :as edn]
-            [clojure.stacktrace                :as st]
             [clojure.string                    :as str]
             [config.interface                  :refer [get-config]]
             [logging.interface                 :as l :refer [log-str]]

--- a/projects/behave/src/clj/behave/handlers.clj
+++ b/projects/behave/src/clj/behave/handlers.clj
@@ -1,7 +1,7 @@
 (ns behave.handlers
   (:require [behave-routing.main               :refer [routes]]
             [behave.download-vms               :refer [export-from-vms export-images-from-vms]]
-            [behave.init                       :refer [init-handler]]
+            [behave.init                       :refer [active-clients init-handler]]
             [behave.open                       :refer [open-handler]]
             [behave.save                       :refer [save-handler]]
             [behave.sync                       :refer [sync-handler]]
@@ -14,8 +14,8 @@
             [config.interface                  :refer [get-config]]
             [logging.interface                 :as l :refer [log-str]]
             [ring.middleware.content-type      :refer [wrap-content-type]]
-            [ring.middleware.multipart-params  :refer [wrap-multipart-params]]
             [ring.middleware.keyword-params    :refer [wrap-keyword-params]]
+            [ring.middleware.multipart-params  :refer [wrap-multipart-params]]
             [ring.middleware.reload            :refer [wrap-reload]]
             [ring.middleware.resource          :refer [wrap-resource]]
             [ring.util.codec                   :refer [url-decode]]
@@ -40,7 +40,7 @@
   (inst-ms (java.util.Date.)))
 
 (defn- kill-app!
-  "Use Runtime exit to kill entire JVM Process"
+  "Use Runtime exit to kill entire JVM Process."
   []
   (.exit (Runtime/getRuntime) 0))
 
@@ -77,13 +77,18 @@
   (if (= (get-config :server :mode) "prod")
     (let [{:keys [cancel]} params]
       (cond
-        (nil? cancel)
+        cancel
         (do
-          (reset! close-time (now-in-ms))
-          (put! @kill-channel true))
+          (swap! active-clients inc)
+          (log-str [:CLIENTS :cancel-close @active-clients])
+          (put! @cancel-channel true))
 
         :else
-        (put! @cancel-channel true))
+        (let [n (swap! active-clients dec)]
+          (log-str [:CLIENTS :close n])
+          (reset! close-time (now-in-ms))
+          (when (<= n 0)
+            (put! @kill-channel true))))
       {:status 200 :body "OK"})
     {:status 404 :body "Not Found"}))
 
@@ -113,8 +118,8 @@
                         (str/split #"&"))
             params  (reduce (fn [params keyval]
                               (let [[k v] (str/split keyval #"=")]
-                               (assoc params (keyword k) (edn/read-string v))))
-                           params keyvals)]
+                                (assoc params (keyword k) (edn/read-string v))))
+                            params keyvals)]
         (handler (assoc req :params params))))))
 
 (defn- wrap-params [handler]
@@ -167,30 +172,33 @@
   (fn [request]
     (handler (assoc request :figwheel? figwheel?))))
 
-(defn server-handler-stack
-  "Server handler stack."
-  [{:keys [reload? figwheel?]}]
+(defn handler-stack
+  "Unified handler stack. Options:
+   - `:cef?`      Skip resource serving and multipart (CEF handles these)
+   - `:reload?`   Enable hot-reload middleware
+   - `:figwheel?` Attach figwheel context to requests"
+  [{:keys [cef? reload? figwheel?]}]
   (-> routing-handler
       (wrap-figwheel figwheel?)
       wrap-params
       wrap-keyword-params
       wrap-query-params
       wrap-req-content-type+accept
-      (wrap-resource "public" {:allow-symlinks? true})
-      (wrap-content-type {:mime-types {"wasm" "application/wasm"}})
-      wrap-multipart-params
+      (optional-middleware #(wrap-resource % "public" {:allow-symlinks? true}) (not cef?))
+      (optional-middleware #(wrap-content-type % {:mime-types {"wasm" "application/wasm"}}) (not cef?))
+      (optional-middleware wrap-multipart-params (not cef?))
       wrap-exceptions
       (optional-middleware #(wrap-reload % {:dirs (reloadable-clj-files)}) reload?)))
 
+(defn server-handler-stack
+  "Server handler stack."
+  [{:keys [reload? figwheel?]}]
+  (handler-stack {:reload? reload? :figwheel? figwheel?}))
+
 (defn create-cef-handler-stack
-  "Custom handler stack for Chrome Embedded Framework."
+  "Handler stack for Chrome Embedded Framework."
   []
-  (-> routing-handler
-      wrap-params
-      wrap-keyword-params
-      wrap-query-params
-      wrap-req-content-type+accept
-      wrap-exceptions))
+  (handler-stack {:cef? true}))
 
 ;; This is for Figwheel
 (def ^{:doc "Figwheel handler."}

--- a/projects/behave/src/clj/behave/init.clj
+++ b/projects/behave/src/clj/behave/init.clj
@@ -10,6 +10,20 @@
             [transport.interface        :refer [clj-> mime->type]])
   (:import (java.io ByteArrayInputStream)))
 
+;;; Client Tracking
+
+(def active-clients
+  "Number of connected browser windows/tabs."
+  (atom 0))
+
+(defn register-client!
+  "Increments the active client count. Call on each /api/init."
+  []
+  (let [n (swap! active-clients inc)]
+    (log-str [:CLIENTS :register n])))
+
+;;; Helpers
+
 (defn- resource [s]
   (.getResource (ClassLoader/getSystemClassLoader) s))
 
@@ -25,7 +39,8 @@
 (defn init-handler [{:keys [request-method accept] :as req}]
   (log-str "Request Received:" (select-keys req [:uri :request-method :params]))
   (let [res-type (or (mime->type accept) :edn)]
-    (when (and (= request-method :get))
+    (when (= request-method :get)
+      (register-client!)
       (s/release-conn!)
       (reset! current-worksheet-atom nil)
       (init!)

--- a/projects/behave/src/clj/behave/server.clj
+++ b/projects/behave/src/clj/behave/server.clj
@@ -26,9 +26,10 @@
 (defn init-db!
   "Initialize DB using configuration."
   [database-config]
-  (log-str [:DB-CONFIG database-config])
-  (io/make-parents (get-in database-config [:store :path]))
-  (store/connect! database-config))
+  (let [database-config (update-in database-config [:store :path] os-path)]
+    (log-str [:DB-CONFIG database-config])
+    (io/make-parents (get-in database-config [:store :path]))
+    (store/connect! database-config)))
 
 ;;; Logging
 

--- a/projects/behave/src/clj/behave/server.clj
+++ b/projects/behave/src/clj/behave/server.clj
@@ -1,10 +1,10 @@
 (ns behave.server
   (:gen-class)
-  (:require [behave.store         :as store]
-            [behave.handlers      :refer [server-handler-stack vms-sync! watch-kill-signal!]]
+  (:require [behave.handlers      :refer [server-handler-stack vms-sync! watch-kill-signal!]]
+            [behave.store         :as store]
             [clojure.java.browse  :refer [browse-url]]
             [clojure.java.io      :as io]
-            [config.interface     :refer [get-config load-config]]
+            [config.interface     :refer [get-config load-config merge-config!]]
             [file-utils.interface :refer [os-path]]
             [logging.interface    :as l :refer [log-str]]
             [server.interface     :as server]))
@@ -12,6 +12,16 @@
 #_{:clj-kondo/ignore [:missing-docstring]}
 (defn init-config! []
   (load-config (io/resource "config.edn")))
+
+(defn enrich-config!
+  "Computes runtime values and merges them into loaded config."
+  []
+  (let [cef?       (some? (System/getProperty "app.dir"))
+        mode       (or (get-config :server :mode)
+                       (if cef? "prod" "dev"))
+        jar-local? (and (= mode "prod") (not cef?))]
+    (merge-config! {:server {:mode mode}
+                    :client {:jar-local? jar-local?}})))
 
 (defn init-db!
   "Initialize DB using configuration."
@@ -38,6 +48,7 @@
   "Starts the Behave7 Application server."
   []
   (init-config!)
+  (enrich-config!)
   (let [mode      (get-config :server :mode)
         http-port (or (get-config :server :http-port) 8080)
         org-name  (get-config :site :org-name)


### PR DESCRIPTION
## Purpose
Reworks the `behave.core/-main` to auto-detect when the application is
running under JAR-mode vs. Conveyor/Executable mode.

## Related Issues
Closes BHP1-1479


## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Copy standalone config: 
`cd projects/behave/resources && cp config.standalone.edn config.edn` 

2. Use `bb build-js` to build the static assets

3. Use `bb uber` to build the UberJar

4. Verify that you when you double-click the JAR file, Behave starts
   in server mode and your default browser opens