### PR TITLE
BHP1-1550 Fix Conveyor app icon to always use BH7 logo

### DIFF
--- a/projects/behave/conveyor.base.conf
+++ b/projects/behave/conveyor.base.conf
@@ -27,9 +27,7 @@ jcef {
 app {
   # Windows gets square icons, macOS and Linux icons with rounded corners.
   version = 7.1.4
-  icons = {
-    label = "Behave7"
-  }
+  icons = "resources/public/images/logo.svg"
   # url-schemes = [ bp ]
   file-associations = [ .bp7 ]
 

--- a/projects/behave/conveyor.windows.conf
+++ b/projects/behave/conveyor.windows.conf
@@ -20,6 +20,7 @@ app {
     package-extras += "zip-extras/Behave7.lnk"
 
     sign = false
+    override-icon = false
   }
 }
 


### PR DESCRIPTION
## Purpose
EOM

## Related Issues
https://sig-gis.atlassian.net/browse/BHP1-1550