### PR TITLE
[BHP1-1554] Fix Output Column Disappearing from Results when map units enabled

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -192,28 +192,28 @@
         [regular-column-headers
          map-units-column-headers]   (reduce (fn [[reg mu] {output-gv-uuid :bp/uuid output-units :units}]
                                                (let [output-name @(subscribe [:wizard/gv-uuid->resolve-result-variable-name output-gv-uuid])]
-                                                 (if (process-map-units? output-gv-uuid)
-                                                   [reg (conj mu {:name (header-label output-name units)
-                                                                  :key  (map-units-column-key output-gv-uuid)})]
-                                                   [(conj reg {:name (header-label output-name output-units)
-                                                               :key  output-gv-uuid})
-                                                    mu])))
+                                                 [(conj reg {:name (header-label output-name output-units)
+                                                             :key  output-gv-uuid})
+                                                  (if (process-map-units? output-gv-uuid)
+                                                    (conj mu {:name (header-label output-name units)
+                                                              :key  (map-units-column-key output-gv-uuid)})
+                                                    mu)]))
                                              [[] []]
                                              output-entities)
         [matrix-data-formatted
          map-units-data]             (reduce-kv (fn [[reg mu] [row col-uuid] v]
                                                   (let [fmt-fn  (get formatters col-uuid identity)
                                                         shaded? (contains? rows-to-shade-set row)]
-                                                    (if (process-map-units? col-uuid)
-                                                      [reg (assoc mu [(input-fmt-fn row) (map-units-column-key col-uuid)]
-                                                                  (format-matrix-cell
-                                                                   (convert-to-map-units v (get units-lookup col-uuid) units rep-fraction)
-                                                                   fmt-fn
-                                                                   shaded?
-                                                                   (not shaded?)))]
-                                                      [(assoc reg [(input-fmt-fn row) col-uuid]
-                                                              (format-matrix-cell v fmt-fn shaded? (not shaded?)))
-                                                       mu])))
+                                                    [(assoc reg [(input-fmt-fn row) col-uuid]
+                                                            (format-matrix-cell v fmt-fn shaded? (not shaded?)))
+                                                     (if (process-map-units? col-uuid)
+                                                       (assoc mu [(input-fmt-fn row) (map-units-column-key col-uuid)]
+                                                              (format-matrix-cell
+                                                               (convert-to-map-units v (get units-lookup col-uuid) units rep-fraction)
+                                                               fmt-fn
+                                                               shaded?
+                                                               (not shaded?)))
+                                                       mu)]))
                                                 [{} {}]
                                                 matrix-data-raw)
         row-headers                  (map (fn [value] {:name (input-fmt-fn value) :key (input-fmt-fn value)}) multi-var-values)


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1554

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open this worksheet: 
[BHP1-1554.zip](https://github.com/user-attachments/files/26985625/BHP1-1554.zip)

2. Navigate to results and ensure that Heading Spread Distance shows in both regular outputs table and map units table

## Screenshots
<img width="695" height="341" alt="image" src="https://github.com/user-attachments/assets/449cb1dd-996b-4891-8f0a-a19ff85794ae" />
