### PR TITLE
[BHP1-1560] Fix values <1 not showing

### DIFF
--- a/projects/behave/src/cljs/behave/settings/events.cljs
+++ b/projects/behave/src/cljs/behave/settings/events.cljs
@@ -21,8 +21,9 @@
 (rf/reg-event-fx
  :settings/cache-decimal-preference
  (fn [_ [_ domain v-uuid decimal]]
-   {:fx [[:dispatch [:settings/set [:units domain v-uuid :decimals] decimal]]
-         [:dispatch [:local-storage/update-in [:units v-uuid :decimals] decimal]]]}))
+   (let [decimal (js/parseInt decimal 10)]
+     {:fx [[:dispatch [:settings/set [:units domain v-uuid :decimals] decimal]]
+           [:dispatch [:local-storage/update-in [:units v-uuid :decimals] decimal]]]})))
 
 (rf/reg-event-fx
  :settings/load-units-from-local-storage
@@ -31,7 +32,7 @@
 
  (fn [{units-settings :settings/all-units+decimals} _]
    {:fx (into []
-              (for [[domain settings] units-settings
+              (for [[domain settings]         units-settings
                     [_
                      domain-name
                      domain-uuid
@@ -40,7 +41,7 @@
                      native-domain-unit-uuid
                      english-domain-unit-uuid
                      metric-domain-unit-uuid
-                     decimals]        settings]
+                     decimals]                settings]
                 [:dispatch [:settings/set [:units domain domain-uuid]
                             {:domain-name              domain-name
                              :domain-dimension-uuid    domain-dimension-uuid

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -755,9 +755,15 @@
         (fn continuous-fmt [value]
           (let [float-value (parse-float value)]
             (cond
-              (and (= significant-digits "0") (< 0 float-value 1)) "< 1"
-              (and significant-digits is-output?)                  (gstring/format (str "%." significant-digits "f") float-value)
-              :else                                                float-value))))
+              (and (= significant-digits 0)
+                   (< 0 float-value 1))
+              "< 1"
+
+              (and significant-digits is-output?)
+              (gstring/format (str "%." significant-digits "f") float-value)
+
+              :else
+              float-value))))
 
       (or (= v-kind :discrete) multi-discrete?)
       (let [{llist :variable/list}  (d/pull @@vms-conn '[{:variable/list [* {:list/options [*]}]}] (:db/id variable))


### PR DESCRIPTION
-------

## Purpose

The issue was that for the unit decimals that came from the vms vs a user updated custom unit preferences were different primitive types. VMS default stred as long and user updated preference stored as string. The Fix, is to ensure user saved preferences are stored as long.

## Related Issues
Closes BHP1-1560

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. open this worksheet: 
[BHP1-1560.zip](https://github.com/user-attachments/files/27024223/BHP1-1560.zip)

2. Navigate to results page
3. Ensure you see <1 in result table

## Screenshots