### PR TITLE
[BHP1-1564]

### DIFF
--- a/projects/behave/src/cljs/behave/wizard/events.cljs
+++ b/projects/behave/src/cljs/behave/wizard/events.cljs
@@ -46,9 +46,9 @@
             (= io :input))
        (-> (dissoc :fx)
            (assoc :async-flow
-                  {:first-dispatch [:worksheet/proccess-conditonally-set-output-group-variables ws-uuid]
+                  {:first-dispatch [:worksheet/proccess-group-variables-with-actions-but-not-conditionally-set ws-uuid]
                    :rules          [{:when     :seen?
-                                     :events   :worksheet/proccess-conditonally-set-output-group-variables
+                                     :events   :worksheet/proccess-group-variables-with-actions-but-not-conditionally-set
                                      :dispatch [:navigate path]
                                      :halt?    true}]}))))))
 
@@ -86,9 +86,9 @@
                                     (= current-io :output)
                                     (= next-io :input))]
      (if guided-output->input?
-       {:async-flow {:first-dispatch [:worksheet/proccess-conditonally-set-output-group-variables ws-uuid]
+       {:async-flow {:first-dispatch [:worksheet/proccess-group-variables-with-actions-but-not-conditionally-set ws-uuid]
                      :rules          [{:when     :seen?
-                                       :events   :worksheet/proccess-conditonally-set-output-group-variables
+                                       :events   :worksheet/proccess-group-variables-with-actions-but-not-conditionally-set
                                        :dispatch [:navigate next-path]
                                        :halt?    true}]}}
        {:fx [[:dispatch [:navigate next-path]]]}))))

--- a/projects/behave/src/cljs/behave/wizard/events.cljs
+++ b/projects/behave/src/cljs/behave/wizard/events.cljs
@@ -46,9 +46,9 @@
             (= io :input))
        (-> (dissoc :fx)
            (assoc :async-flow
-                  {:first-dispatch [:worksheet/proccess-group-variables-with-actions-but-not-conditionally-set ws-uuid]
+                  {:first-dispatch [:worksheet/proccess-output-group-variables-with-actions ws-uuid]
                    :rules          [{:when     :seen?
-                                     :events   :worksheet/proccess-group-variables-with-actions-but-not-conditionally-set
+                                     :events   :worksheet/proccess-output-group-variables-with-actions
                                      :dispatch [:navigate path]
                                      :halt?    true}]}))))))
 
@@ -86,9 +86,9 @@
                                     (= current-io :output)
                                     (= next-io :input))]
      (if guided-output->input?
-       {:async-flow {:first-dispatch [:worksheet/proccess-group-variables-with-actions-but-not-conditionally-set ws-uuid]
+       {:async-flow {:first-dispatch [:worksheet/proccess-output-group-variables-with-actions ws-uuid]
                      :rules          [{:when     :seen?
-                                       :events   :worksheet/proccess-group-variables-with-actions-but-not-conditionally-set
+                                       :events   :worksheet/proccess-output-group-variables-with-actions
                                        :dispatch [:navigate next-path]
                                        :halt?    true}]}}
        {:fx [[:dispatch [:navigate next-path]]]}))))

--- a/projects/behave/src/cljs/behave/wizard/subs.cljs
+++ b/projects/behave/src/cljs/behave/wizard/subs.cljs
@@ -764,50 +764,42 @@
          parsed-values (map js/parseFloat (str/split values ","))]
      [0 (apply max parsed-values)])))
 
+(defn- query-module-group-variables
+  [db modules io extra-where]
+  (let [module-eids (mapv :db/id modules)
+        query       (conj '[:find  [?gv ...]
+                            :in    $ % [?module-eid ...] ?io
+                            :where
+                            [?module-eid :module/submodules ?s]
+                            [?s :submodule/io ?io]
+                            (group ?s ?g)
+                            [?g :group/group-variables ?gv]]
+                          extra-where)
+        gv-eids     (d/q query db rules module-eids io)]
+    (mapv #(d/entity db %) gv-eids)))
+
 (reg-sub
  :wizard/conditionally-set-group-variables
 
  (fn [[_ ws-uuid]]
    (subscribe [:worksheet/modules ws-uuid]))
  (fn [modules [_ _ io]]
-   (let [db          @@vms-conn
-         module-eids (mapv :db/id modules)
-         gv-eids     (d/q '[:find [?gv ...]
-                            :in    $ % [?module-eid ...] ?io
-                            :where
-                            [?module-eid :module/submodules ?s]
-                            [?s :submodule/io ?io]
-                            (group ?s ?g)
-                            [?g :group/group-variables ?gv]
-                            [?gv :group-variable/conditionally-set? true]]
-                          db rules module-eids io)]
-
-     (mapv #(d/entity db %) gv-eids))))
+   (query-module-group-variables @@vms-conn modules io
+                                 '[?gv :group-variable/conditionally-set? true])))
 
 (reg-sub
- :wizard/group-variables-with-actions-but-not-conditionally-set
+ :wizard/output-group-variables-with-actions
 
  (fn [[_ ws-uuid]]
    [(subscribe [:worksheet/modules ws-uuid])
     (subscribe [:worksheet/all-output-uuids ws-uuid])])
 
- (fn [[modules worksheet-output-uuids] [_ _ io]]
-   (let [db          @@vms-conn
-         module-eids (mapv :db/id modules)
-         output-set  (set worksheet-output-uuids)
-         gv-eids     (d/q '[:find [?gv ...]
-                            :in    $ % [?module-eid ...] ?io
-                            :where
-                            [?module-eid :module/submodules ?s]
-                            [?s :submodule/io ?io]
-                            (group ?s ?g)
-                            [?g :group/group-variables ?gv]
-                            [?gv :group-variable/actions _]]
-                          db rules module-eids io)]
+ (fn [[modules worksheet-output-uuids] _]
+   (let [output-set (set worksheet-output-uuids)]
      (into []
-           (comp (map #(d/entity db %))
-                 (remove #(contains? output-set (:bp/uuid %))))
-           gv-eids))))
+           (remove #(contains? output-set (:bp/uuid %)))
+           (query-module-group-variables @@vms-conn modules :output
+                                         '[?gv :group-variable/actions _])))))
 
 (reg-sub
  :wizard/conditionally-set-input-data

--- a/projects/behave/src/cljs/behave/wizard/subs.cljs
+++ b/projects/behave/src/cljs/behave/wizard/subs.cljs
@@ -768,6 +768,26 @@
  :wizard/conditionally-set-group-variables
 
  (fn [[_ ws-uuid]]
+   (subscribe [:worksheet/modules ws-uuid]))
+ (fn [modules [_ _ io]]
+   (let [db          @@vms-conn
+         module-eids (mapv :db/id modules)
+         gv-eids     (d/q '[:find [?gv ...]
+                            :in    $ % [?module-eid ...] ?io
+                            :where
+                            [?module-eid :module/submodules ?s]
+                            [?s :submodule/io ?io]
+                            (group ?s ?g)
+                            [?g :group/group-variables ?gv]
+                            [?gv :group-variable/conditionally-set? true]]
+                          db rules module-eids io)]
+
+     (mapv #(d/entity db %) gv-eids))))
+
+(reg-sub
+ :wizard/group-variables-with-actions-but-not-conditionally-set
+
+ (fn [[_ ws-uuid]]
    [(subscribe [:worksheet/modules ws-uuid])
     (subscribe [:worksheet/all-output-uuids ws-uuid])])
 
@@ -782,8 +802,7 @@
                             [?s :submodule/io ?io]
                             (group ?s ?g)
                             [?g :group/group-variables ?gv]
-                            (or [?gv :group-variable/conditionally-set? true]
-                                [?gv :group-variable/actions _])]
+                            [?gv :group-variable/actions _]]
                           db rules module-eids io)]
      (into []
            (comp (map #(d/entity db %))

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -44,6 +44,23 @@
          [?i :input/value ?value]]
        conn ws-uuid group-uuid repeat-id))
 
+(defn- process-output-actions->fx
+  [worksheet group-variables ws-uuid]
+  (let [reset-map   (zipmap (map :bp/uuid group-variables) (repeat false))
+        enabled-map (->> group-variables
+                         (mapcat (fn [{group-variable-uuid :bp/uuid
+                                       actions             :group-variable/actions}]
+                                   (for [{atype           :action/type
+                                          conditionals    :action/conditionals
+                                          conditionals-op :action/conditionals-operator} actions
+                                         :when                                           (and (= :select atype)
+                                                                                              (all-conditionals-pass? worksheet conditionals-op conditionals))]
+                                     [group-variable-uuid true])))
+                         (into {}))
+        merged-map  (merge reset-map enabled-map)
+        payload     (mapv (fn [[gv-uuid v]] [:dispatch [:worksheet/upsert-output ws-uuid gv-uuid v]]) merged-map)]
+    {:fx payload}))
+
 (defn ^:private add-input-group-tx [ws-uuid group-uuid repeat-id]
   {:db/id                   -1
    :worksheet/_input-groups [:worksheet/uuid ws-uuid]
@@ -955,27 +972,14 @@
      {:transact payload})))
 
 (rf/reg-event-fx
- :worksheet/proccess-group-variables-with-actions-but-not-conditionally-set
+ :worksheet/proccess-output-group-variables-with-actions
 
  [(rf/inject-cofx ::inject/sub (fn [[_ ws-uuid]] [:worksheet ws-uuid]))
-  (rf/inject-cofx ::inject/sub (fn [[_ ws-uuid]] [:wizard/group-variables-with-actions-but-not-conditionally-set ws-uuid :output]))]
+  (rf/inject-cofx ::inject/sub (fn [[_ ws-uuid]] [:wizard/output-group-variables-with-actions ws-uuid]))]
 
  (fn [{worksheet       :worksheet
-       group-variables :wizard/group-variables-with-actions-but-not-conditionally-set} [_ ws-uuid]]
-   (let [reset-map   (zipmap (map :bp/uuid group-variables) (repeat false))
-         enabled-map (->> group-variables
-                          (mapcat (fn [{group-variable-uuid :bp/uuid
-                                        actions             :group-variable/actions}]
-                                    (for [{atype           :action/type
-                                           conditionals    :action/conditionals
-                                           conditionals-op :action/conditionals-operator} actions
-                                          :when                                           (and (= :select atype)
-                                                                                               (all-conditionals-pass? worksheet conditionals-op conditionals))]
-                                      [group-variable-uuid true])))
-                          (into {}))
-         merged-map  (merge reset-map enabled-map)
-         payload     (mapv (fn [[gv-uuid v]] [:dispatch [:worksheet/upsert-output ws-uuid gv-uuid v]]) merged-map)]
-     {:fx payload})))
+       group-variables :wizard/output-group-variables-with-actions} [_ ws-uuid]]
+   (process-output-actions->fx worksheet group-variables ws-uuid)))
 
 (rf/reg-event-fx
  :worksheet/proccess-conditonally-set-output-group-variables
@@ -985,20 +989,7 @@
 
  (fn [{worksheet       :worksheet
        group-variables :wizard/conditionally-set-group-variables} [_ ws-uuid]]
-   (let [reset-map   (zipmap (map :bp/uuid group-variables) (repeat false))
-         enabled-map (->> group-variables
-                          (mapcat (fn [{group-variable-uuid :bp/uuid
-                                        actions             :group-variable/actions}]
-                                    (for [{atype           :action/type
-                                           conditionals    :action/conditionals
-                                           conditionals-op :action/conditionals-operator} actions
-                                          :when                                           (and (= :select atype)
-                                                                                               (all-conditionals-pass? worksheet conditionals-op conditionals))]
-                                      [group-variable-uuid true])))
-                          (into {}))
-         merged-map  (merge reset-map enabled-map)
-         payload     (mapv (fn [[gv-uuid v]] [:dispatch [:worksheet/upsert-output ws-uuid gv-uuid v]]) merged-map)]
-     {:fx payload})))
+   (process-output-actions->fx worksheet group-variables ws-uuid)))
 
 (rf/reg-event-fx
  :worksheet/select-single-select-output

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -567,13 +567,13 @@
  (fn [{ds                   :ds
        directional-children :vms/directional-children} [_ ws-uuid group-var-uuid attr value]]
    (when-let [table-filter-id (get-table-filter-eid ds ws-uuid group-var-uuid)]
-     (let [children-payload (map (fn [child]
-                                   (let [child-table-filter-id
-                                         (get-table-filter-eid ds ws-uuid (:bp/uuid child))]
-                                     (assoc {:db/id child-table-filter-id} attr value)))
-                                 directional-children)]
-       {:transact (cond-> [(assoc {:db/id table-filter-id} attr value)]
-                    (seq children-payload) (concat children-payload))}))))
+     (let [children-payload (for [child directional-children
+                                  :let  [child-table-filter-id (get-table-filter-eid ds ws-uuid (:bp/uuid child))]
+                                  :when child-table-filter-id]
+                              (assoc {:db/id child-table-filter-id} attr value))
+           payload          (cond-> [(assoc {:db/id table-filter-id} attr value)]
+                              (seq children-payload) (concat children-payload))]
+       {:transact payload}))))
 
 (rp/reg-event-fx
  :worksheet/add-table-filter
@@ -953,6 +953,29 @@
                     [:db.fn/retractEntity input-eid])
                   input-eids)]
      {:transact payload})))
+
+(rf/reg-event-fx
+ :worksheet/proccess-group-variables-with-actions-but-not-conditionally-set
+
+ [(rf/inject-cofx ::inject/sub (fn [[_ ws-uuid]] [:worksheet ws-uuid]))
+  (rf/inject-cofx ::inject/sub (fn [[_ ws-uuid]] [:wizard/group-variables-with-actions-but-not-conditionally-set ws-uuid :output]))]
+
+ (fn [{worksheet       :worksheet
+       group-variables :wizard/group-variables-with-actions-but-not-conditionally-set} [_ ws-uuid]]
+   (let [reset-map   (zipmap (map :bp/uuid group-variables) (repeat false))
+         enabled-map (->> group-variables
+                          (mapcat (fn [{group-variable-uuid :bp/uuid
+                                        actions             :group-variable/actions}]
+                                    (for [{atype           :action/type
+                                           conditionals    :action/conditionals
+                                           conditionals-op :action/conditionals-operator} actions
+                                          :when                                           (and (= :select atype)
+                                                                                               (all-conditionals-pass? worksheet conditionals-op conditionals))]
+                                      [group-variable-uuid true])))
+                          (into {}))
+         merged-map  (merge reset-map enabled-map)
+         payload     (mapv (fn [[gv-uuid v]] [:dispatch [:worksheet/upsert-output ws-uuid gv-uuid v]]) merged-map)]
+     {:fx payload})))
 
 (rf/reg-event-fx
  :worksheet/proccess-conditonally-set-output-group-variables


### PR DESCRIPTION
## Purpose

- A bug was introduced in the work with ensuring output default values were set even though the user did not select the output submodule tab to kick off the action. The bug caused normal runs to not re-process conditionally set outputs from a previous run.

- Need to separate the list of group variables that moving from output to input page to process :wizard/group-variables-with-actions-but-not-conditionally-set from the list that gets processed right before the solver.

- main difference, is that the output->input process group variables with actions bu NOT necessarily conditionally set. It also filters out any outputs that have already been set, this is important because we don't want to override the users. We can't use this same list (as was done before) for when processing conditionally set outputs right before the solver because it would not re-process outputs that were conditionally set (i.e. heading rate of spread, backing rate of spread, etc) by a previous run.


## Related Issues
Closes BHP1-1564

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open a surface worksheet and complete run
- Direction: Heading
- Rate of Spread
2. Ensure table filters show for rate of spread and outputs are correct
3. Change Direction mode to Heading, Backing, Flanking and ensure outputs and settings are correct
4. Create a surface and contain run
5. Navigate to inputs without selecting Output > Fire Behavior tab
6. Ensure in inputs page submodules are shown, Fuel Model, Fuel Moisture, Wind and Slope



## Screenshots