### PR TITLE
[BHP1-1573] Fix Table Shader Rounding

### DIFF
--- a/bases/behave_components/src/cljs/behave/components/inputs.cljs
+++ b/bases/behave_components/src/cljs/behave/components/inputs.cljs
@@ -1,11 +1,11 @@
 (ns behave.components.inputs
   (:require
-   [behave.components.button :refer [button]]
-   [behave.components.a11y :refer [on-space on-enter]]
+   [behave.components.a11y      :refer [on-space on-enter]]
+   [behave.components.button    :refer [button]]
    [behave.components.icon.core :refer [icon]]
-   [reagent.core :as r]
-   [goog.string :as gstring]
-   [clojure.string :as str]))
+   [clojure.string              :as str]
+   [goog.string                 :as gstring]
+   [reagent.core                :as r]))
 
 ;;==============================================================================
 ;; Checkbox
@@ -62,24 +62,25 @@
 ;;==============================================================================
 
 #_{:clj-kondo/ignore [:shadowed-var]}
-(defn number-input [{:keys [label id name on-change on-blur disabled? error? error-msg min max value value-atom step]}]
+(defn number-input [{:keys [label id name on-change on-blur disabled? error? error-msg min max value value-atom default-value step]}]
   [:div {:class ["input-number " (when error? "input-number--error")]}
    [:label
     {:class "input-number__label" :for id}
     label]
    [:input
-    (cond-> {:type "number"
-             :class "input-number__input"
-             :disabled disabled?
-             :id id
-             :name name
+    (cond-> {:type      "number"
+             :class     "input-number__input"
+             :disabled  disabled?
+             :id        id
+             :name      name
              :on-change on-change
-             :on-blur on-blur
-             :min min
-             :max max}
-      step       (assoc :step step)
-      value      (assoc :value value)
-      value-atom (assoc :value @value-atom))]
+             :on-blur   on-blur
+             :min       min
+             :max       max}
+      step          (assoc :step step)
+      value         (assoc :value value)
+      value-atom    (assoc :value @value-atom)
+      default-value (assoc :default-value default-value))]
    (when error?
      [:div.input-number__error error-msg])])
 
@@ -223,15 +224,15 @@
                  (when disabled? "input-text--disabled")
                  (when focused? "input-text--focused")]}
    [:label {:class "input-text__label" :for id} label]
-   [:input (cond-> {:class "input-text__input"
-                    :disabled disabled?
-                    :id id
-                    :name name
-                    :on-blur on-blur
+   [:input (cond-> {:class        "input-text__input"
+                    :disabled     disabled?
+                    :id           id
+                    :name         name
+                    :on-blur      on-blur
                     :on-key-press on-key-press
-                    :on-focus on-focus
-                    :placeholder placeholder
-                    :type "text"}
+                    :on-focus     on-focus
+                    :placeholder  placeholder
+                    :type         "text"}
              background    (assoc :style {:background background})
              font-color    (assoc-in [:style :color] font-color)
              on-change     (assoc :on-change on-change)
@@ -259,10 +260,10 @@
   (-> event .-target .-value))
 
 (defn- multi-select-option [{:keys [selected? label on-click color-tag]}]
-  [:div (cond-> {:class ["multi-select__option"
-                         (when selected? "multi-select__option--selected")
-                         (when color-tag "multi-select__option__color-tag")]
-                 :style {}
+  [:div (cond-> {:class    ["multi-select__option"
+                            (when selected? "multi-select__option--selected")
+                            (when color-tag "multi-select__option__color-tag")]
+                 :style    {}
                  :on-click on-click}
           color-tag
           (assoc-in [:style :border-color] (:color color-tag)))
@@ -380,9 +381,9 @@
       (when (false? @show-options?)
         [:div.multi-select__selections__body (for [[label value on-deselect color-tag :as selection] @selections]
                                                [:div
-                                                (cond-> {:class ["multi-select__option--selected"
-                                                                 (when color-tag "multi-select__option__color-tag")]
-                                                         :style {}
+                                                (cond-> {:class    ["multi-select__option--selected"
+                                                                    (when color-tag "multi-select__option__color-tag")]
+                                                         :style    {}
                                                          :on-click #(do
                                                                       (reset! selections (disj @selections selection))
                                                                       (when on-deselect (on-deselect value)))}
@@ -431,10 +432,10 @@
       [:div.multi-select-search__selections__body
        (for [[label value on-deselect color-tag :as selection] @selections]
          [:div
-          (cond-> {:class ["multi-select-search"
-                           "multi-select__option--selected"
-                           (when color-tag "multi-select__option__color-tag")]
-                   :style {}
+          (cond-> {:class    ["multi-select-search"
+                              "multi-select__option--selected"
+                              (when color-tag "multi-select__option__color-tag")]
+                   :style    {}
                    :on-click #(do
                                 (reset! selections (disj @selections selection))
                                 (when on-deselect (on-deselect value)))}

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -2,7 +2,6 @@
   (:require [behave.components.core  :as c]
             [behave.translate        :refer [<t bp]]
             [behave.units-conversion :refer [to-map-units]]
-            [cljs.math               :refer [round]]
             [clojure.string          :as str]
             [goog.string             :as gstring]
             [map-utils.interface     :as map-utils]
@@ -42,12 +41,18 @@
        {}
        entries-by-row))))
 
-(defn- shade-cell-value? [table-setting-filters output-gv-uuid value]
-  (let [[_ mmin mmax enabled?] (first (filter
-                                       (fn [[gv-uuid]]
-                                         (= gv-uuid output-gv-uuid))
-                                       table-setting-filters))]
-    (and enabled? mmin mmax (not (<= mmin (round value) mmax)))))
+(defn- shade-cell-value? [table-setting-filters sig-digits output-gv-uuid value]
+  (let [[_ mmin mmax enabled?] (first (filter (fn [[gv-uuid]] (= gv-uuid output-gv-uuid))
+                                              table-setting-filters))
+        sig                    (get sig-digits output-gv-uuid)
+        rround                 (fn [n]
+                                 (if (and sig (some? n))
+                                   (js/parseFloat (gstring/format (str "%." sig "f") n))
+                                   n))
+        rounded                (rround (js/parseFloat value))
+        rounded-min            (rround mmin)
+        rounded-max            (rround mmax)]
+    (and enabled? mmin mmax (not (<= rounded-min rounded rounded-max)))))
 
 (defn- header-label [label units]
   (if (seq units)
@@ -94,7 +99,7 @@
                   :output-gv-uuid output-gv-uuid}])))
 
 (defn- compute-shade-set-2d
-  [{:keys [ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-entities table-setting-filters submatrix-gv-uuid submatrix-value]}]
+  [{:keys [ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-entities table-setting-filters sig-digits submatrix-gv-uuid submatrix-value]}]
   (reduce (fn [acc {output-gv-uuid :bp/uuid}]
             (let [matrix-data (fetch-matrix-data-2d {:ws-uuid           ws-uuid
                                                      :row-gv-uuid       row-gv-uuid
@@ -108,7 +113,7 @@
                     (reduce-kv
                      (fn [acc [row col] value]
                        (cond-> acc
-                         (shade-cell-value? table-setting-filters output-gv-uuid value)
+                         (shade-cell-value? table-setting-filters sig-digits output-gv-uuid value)
                          (conj [row col])))
                      #{}
                      matrix-data))))
@@ -116,7 +121,7 @@
           output-entities))
 
 (defn- compute-shade-set
-  [{:keys [ws-uuid multi-valued-inputs all-output-gv-uuids all-output-entities graph-settings table-setting-filters]}]
+  [{:keys [ws-uuid multi-valued-inputs all-output-gv-uuids all-output-entities graph-settings table-setting-filters sig-digits]}]
   (case (count multi-valued-inputs)
     1 (let [[_ _ multi-var-gv-uuid multi-var-values] (first multi-valued-inputs)
             all-matrix-data-raw                      @(subscribe [:worksheet/matrix-table-data-single-multi-valued-input
@@ -126,7 +131,7 @@
                                                                   (vec all-output-gv-uuids)])]
         (reduce-kv (fn [acc [row col-uuid] v]
                      (cond-> acc
-                       (shade-cell-value? table-setting-filters col-uuid v)
+                       (shade-cell-value? table-setting-filters sig-digits col-uuid v)
                        (conj row)))
                    #{}
                    all-matrix-data-raw))
@@ -144,7 +149,8 @@
                                :col-gv-uuid           col-gv-uuid
                                :col-values            col-values
                                :output-entities       all-output-entities
-                               :table-setting-filters table-setting-filters}))
+                               :table-setting-filters table-setting-filters
+                               :sig-digits            sig-digits}))
     3 (let [z2-axis-uuid                 (:graph-settings/z2-axis-group-variable-uuid graph-settings)
             [_ _ z2-gv-uuid z2-values]   (->> multi-valued-inputs
                                               (filter (fn [[_ _ gv-uuid]] (= gv-uuid z2-axis-uuid)))
@@ -167,6 +173,7 @@
                                                 :col-values            col-values
                                                 :output-entities       all-output-entities
                                                 :table-setting-filters table-setting-filters
+                                                :sig-digits            sig-digits
                                                 :submatrix-gv-uuid     z2-gv-uuid
                                                 :submatrix-value       value})))
                 {}
@@ -540,12 +547,14 @@
         color-output-state              @(subscribe [:wizard/selected-output-cell-coloring])
         cell-color-gv-uuid              (when-not (= :none color-output-state) color-output-state)
         graph-settings                  @(subscribe [:worksheet/graph-settings ws-uuid])
+        sig-digits                      @(subscribe [:worksheet/result-table-significant-digits all-output-gv-uuids])
         shade-set                       (compute-shade-set {:ws-uuid               ws-uuid
                                                             :multi-valued-inputs   multi-valued-inputs
                                                             :all-output-gv-uuids   all-output-gv-uuids
                                                             :all-output-entities   all-output-entities
                                                             :graph-settings        graph-settings
-                                                            :table-setting-filters table-setting-filters})
+                                                            :table-setting-filters table-setting-filters
+                                                            :sig-digits            sig-digits})
         any-filters-enabled?            (boolean (some (fn [[_ _ _ enabled?]] enabled?) table-setting-filters))]
     (when (and (seq discrete-outputs-with-colors) (nil? color-output-state))
       (dispatch-sync [:wizard/set-discrete-color-output (:bp/uuid (first discrete-outputs-with-colors))]))

--- a/projects/behave/src/cljs/behave/settings/events.cljs
+++ b/projects/behave/src/cljs/behave/settings/events.cljs
@@ -22,7 +22,7 @@
  :settings/cache-decimal-preference
  (fn [_ [_ domain v-uuid decimal]]
    (let [decimal (js/parseInt decimal 10)]
-     {:fx [[:dispatch [:settings/set [:units domain v-uuid :decimals] decimal]]
+     {:fx [[:dispatch [:settings/set [:units domain v-uuid :domain-decimals] decimal]]
            [:dispatch [:local-storage/update-in [:units v-uuid :decimals] decimal]]]})))
 
 (rf/reg-event-fx

--- a/projects/behave/src/cljs/behave/settings/views.cljs
+++ b/projects/behave/src/cljs/behave/settings/views.cljs
@@ -70,11 +70,11 @@
                        units on-click])
                     [:div @(rf/subscribe [:vms/units-uuid->short-code domain-native-unit-uuid])])
         :decimals (when (not= domain-decimals "N/A")
-                    (let [decimal-atom (r/atom domain-decimals)]
-                      [c/number-input {:value-atom decimal-atom
-                                       :on-change  #(reset! decimal-atom (input-value %))
-                                       :on-blur    #(rf/dispatch-sync [:settings/cache-decimal-preference
-                                                                       domain-set domain-uuid @decimal-atom])}]))})
+                    ^{:key [domain-uuid domain-decimals]}
+                    [c/number-input {:default-value domain-decimals
+                                     :on-blur       #(rf/dispatch-sync
+                                                      [:settings/cache-decimal-preference
+                                                       domain-set domain-uuid (input-value %)])}])})
      domain-unit-settings)))
 
 (defn- general-units-tab [{:keys [ws-uuid]}]

--- a/projects/behave/src/cljs/behave/settings/views.cljs
+++ b/projects/behave/src/cljs/behave/settings/views.cljs
@@ -4,8 +4,8 @@
    [behave.settings.events]
    [behave.translate       :refer [<t bp]]
    [dom-utils.interface    :refer [input-value]]
-   [reagent.core           :as r]
-   [re-frame.core          :as rf]))
+   [re-frame.core          :as rf]
+   [reagent.core           :as r]))
 
 ;;==============================================================================
 ;; Fuel Model Set Selection Tab

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -795,6 +795,25 @@
                    [gv-uuid (create-formatter variable multi-discrete? is-output?)]))
                results)))))
 
+(rf/reg-sub
+ :worksheet/result-table-significant-digits
+ (fn [_ [_ gv-uuids]]
+   (let [results (d/q '[:find ?gv-uuid (pull ?v [:variable/kind :variable/domain-uuid])
+                        :in $ % [?gv-uuid ...]
+                        :where
+                        (lookup ?gv-uuid ?gv)
+                        (group-variable _ ?gv ?v)]
+                      @@vms-conn rules gv-uuids)]
+     (into {}
+           (keep (fn [[gv-uuid variable]]
+                   (when (= :continuous (:variable/kind variable))
+                     (let [domain-uuid      (:variable/domain-uuid variable)
+                           domain           @(rf/subscribe [:vms/entity-from-uuid domain-uuid])
+                           *cached-decimals (rf/subscribe [:settings/cached-decimal domain-uuid])
+                           sig-digits       (or @*cached-decimals (:domain/decimals domain))]
+                       [gv-uuid sig-digits]))))
+           results))))
+
 (rp/reg-sub
  :worksheet/map-units-settings-eid
  (fn [_ [_ ws-uuid]]


### PR DESCRIPTION
-------

## Purpose

- Table Shaders were incorrectly shading cells because there is a mismatched on what is displayed (rounded value based on precision) vs using un-rounded values in the shading logic. To fix this we need to ensure table shading filters round all values in the logic to the same precision as what is displayed.

## Related Issues
Closes BHP1-1573

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. open this worksheet: [BHP1-1573.zip](https://github.com/user-attachments/files/27729356/BHP1-1573.zip)
2. In settings, change the decimal precision for Surface Rate of Spread to 1
3. Navigate to settings page, take note of the table filter setting. should be 0.2 -> 26
4. Navigate to results and ensure that cells are properly shaded
5. One cell that was not properly shaded previously was:

Backing Rate of Spread (ch/h)
- Fuel Model Code: GR1/101
- Live Herbaceous Fuel Moisture: 120%

The true value of the cell was actually 0.19342908711679715. The old logic did not round this number and flagged it for shading, but what is displayed is 0.2 on the results, so this causes confusion.


## Screenshots