### PR TITLE
[BHP1-1572] Fix Graphs Not Plotting Some Points

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/graphs.cljs
+++ b/projects/behave/src/cljs/behave/components/results/graphs.cljs
@@ -1,5 +1,6 @@
 (ns behave.components.results.graphs
   (:require [behave.components.vega.result-chart :refer [result-chart]]
+            [number-utils.core                   :refer [parse-float]]
             [re-frame.core                       :refer [subscribe]]))
 
 (defn result-graphs [ws-uuid cell-data]
@@ -12,11 +13,9 @@
                                (reduce (fn [acc [_row-id cell-data]]
                                          (conj acc
                                                (->> (reduce (fn [acc [_row-id col-uuid _repeat-id value]]
-                                                              (let [fmt-fn (-> @(subscribe [:worksheet/result-table-formatters [col-uuid]])
-                                                                               (get col-uuid identity))]
-                                                                (assoc acc
-                                                                       @(subscribe [:wizard/gv-uuid->resolve-result-variable-name col-uuid])
-                                                                       (fmt-fn value))))
+                                                              (assoc acc
+                                                                     @(subscribe [:wizard/gv-uuid->resolve-result-variable-name col-uuid])
+                                                                     (parse-float value)))
                                                             {}
                                                             cell-data)
                                                     (remove (fn [[_ value]] (= value -1)))


### PR DESCRIPTION
-------

## Purpose

1. Some points are not being plotted because they were processed through a formatter. This is unnecessary for the graphs, they should plot the raw values of the results

## Related Issues
Closes BHP1-1572

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open this worksheet: 
[BHP1-1572.zip](https://github.com/user-attachments/files/27729389/BHP1-1572.zip)

2. Navigate to results and ensure "Backing Rate of Spread" graph has all the values plotted

## Screenshots

Before:
<img width="462" height="341" alt="image" src="https://github.com/user-attachments/assets/77cc16e5-9a77-4e07-a7e4-d2cfeae48801" />

After:
<img width="481" height="335" alt="image" src="https://github.com/user-attachments/assets/c2a90b07-aaeb-4faf-91de-8e2c1c447cb9" />
