### PR TITLE
Refactor Suggestions

### DIFF
--- a/components/schema_migrate/src/schema_migrate/core.clj
+++ b/components/schema_migrate/src/schema_migrate/core.clj
@@ -13,54 +13,58 @@
   rand-uuid (comp str squuid))
 
 (defn name->uuid
-  "Get the :bp/uuid using the name for the specified name attribute"
-  [conn attr nname]
+  "Get the :bp/uuid using the name for the specified name attribute.
+   Accepts a Datomic conn or db."
+  [db attr nname]
   (d/q '[:find ?uuid .
          :in $ ?attr ?name
          :where
          [?e ?attr ?name]
          [?e :bp/uuid ?uuid]]
-       (d/db conn)
+       (ds/unwrap-db db)
        attr
        nname))
 
 (defn name->nid
-  "Get the :bp/nid using the name for the specified name attribute"
-  [conn attr nname]
+  "Get the :bp/nid using the name for the specified name attribute.
+   Accepts a Datomic conn or db."
+  [db attr nname]
   (d/q '[:find ?nid .
          :in $ ?attr ?name
          :where
          [?e ?attr ?name]
          [?e :bp/nid ?nid]]
-       (d/db conn)
+       (ds/unwrap-db db)
        attr
        nname))
 
 (defn name->eid
   "Get the datomic entity id given the attribute and name. May not work as expected if attr and name
-  is not unique."
-  [conn attr nname]
+  is not unique. Accepts a Datomic conn or db."
+  [db attr nname]
   (d/q '[:find ?e .
          :in $ ?attr ?name
          :where [?e ?attr ?name]]
-       (d/db conn)
+       (ds/unwrap-db db)
        attr
        nname))
 
 (defn cpp-ns->uuid
-  "Given the namespace name, ret the :bp/uuid using the cpp namepsace name"
-  [conn nname]
+  "Given the namespace name, ret the :bp/uuid using the cpp namepsace name.
+   Accepts a Datomic conn or db."
+  [db nname]
   (d/q '[:find ?uuid .
          :in $ ?name
          :where
          [?e :cpp.namespace/name ?name]
          [?e :bp/uuid ?uuid]]
-       (d/db conn)
+       (ds/unwrap-db db)
        nname))
 
 (defn cpp-class->uuid
-  "Given the namespace and class, return the :bp/uuid of the class entity."
-  [conn nnamespace cclass]
+  "Given the namespace and class, return the :bp/uuid of the class entity.
+   Accepts a Datomic conn or db."
+  [db nnamespace cclass]
   (d/q '[:find ?uuid .
          :in $ ?namespace ?class
          :where
@@ -68,13 +72,14 @@
          [?ns :cpp.namespace/class ?c]
          [?c :cpp.class/name ?class]
          [?c :bp/uuid ?uuid]]
-       (d/db conn)
+       (ds/unwrap-db db)
        nnamespace
        cclass))
 
 (defn cpp-fn->uuid
-  "Given the namespace class and function name, return the :bp/uuid of the function entity."
-  ([conn nnamespace cclass fn-name]
+  "Given the namespace class and function name, return the :bp/uuid of the function entity.
+   Accepts a Datomic conn or db."
+  ([db nnamespace cclass fn-name]
    (d/q '[:find ?uuid .
           :in $ ?namespace ?class ?fn-name
           :where
@@ -84,14 +89,15 @@
           [?c :cpp.class/function ?f]
           [?f :cpp.function/name ?fn-name]
           [?f :bp/uuid ?uuid]]
-        (d/db conn)
+        (ds/unwrap-db db)
         nnamespace
         cclass
         fn-name)))
 
 (defn cpp-param->uuid
-  "Given the namespace, class, function name and parameter name, return the :bp/uuid of the parameter entity."
-  ([conn nnamespace cclass fn-name param-name]
+  "Given the namespace, class, function name and parameter name, return the :bp/uuid of the parameter entity.
+   Accepts a Datomic conn or db."
+  ([db nnamespace cclass fn-name param-name]
    (d/q '[:find ?uuid .
           :in $ ?namespace ?class ?fn-name
           :where
@@ -103,7 +109,7 @@
           [?f :cpp.function/parameter ?p]
           [?p :cpp.parameter/name ?param-name]
           [?p :bp/uuid ?uuid]]
-        (d/db conn)
+        (ds/unwrap-db db)
         nnamespace
         cclass
         fn-name
@@ -111,8 +117,9 @@
 
 (defn cpp-uuids
   "Given a map of with the names of a namespace, class and function, return a map
-  that resolves the names to a uuid. Requires all three names."
-  [conn {:keys [cpp-namespace cpp-class cpp-function cpp-param]}]
+  that resolves the names to a uuid. Requires all three names.
+  Accepts a Datomic conn or db."
+  [db {:keys [cpp-namespace cpp-class cpp-function cpp-param]}]
   (first
    (d/q '[:find ?ns-uuid ?c-uuid ?f-uuid ?param-uuid
           :keys cpp-namespace cpp-class cpp-function cpp-param
@@ -129,24 +136,25 @@
           [?f :cpp.function/parameter ?p]
           [?p :cpp.parameter/name ?param-name]
           [?p :bp/uuid ?param-uuid]]
-        (d/db conn)
+        (ds/unwrap-db db)
         cpp-namespace
         cpp-class
         cpp-function
         cpp-param)))
 
-(defn- submodule [conn t]
-  (->> t
-       (d/q '[:find ?e .
-              :in $ ?t
-              :where [?e :submodule/translation-key ?t]]
-            (ds/unwrap-db conn)
-            t)
-       (d/entity (ds/unwrap-db conn))))
+(defn- submodule [db t]
+  (let [db (ds/unwrap-db db)]
+    (->> t
+         (d/q '[:find ?e .
+                :in $ ?t
+                :where [?e :submodule/translation-key ?t]]
+              db
+              t)
+         (d/entity db))))
 
 (defn eid->t-key
-  "Returns an entity's translation key."
-  [conn eid]
+  "Returns an entity's translation key. Accepts a Datomic conn or db."
+  [db eid]
   (d/q '[:find ?k .
          :in $ ?e
          :where
@@ -158,70 +166,74 @@
           [?e :subtool-variable/translation-key ?k]
           [?e :tag/translation-key ?k]
           [?e :tag-set/translation-key ?k]
-          [?e :group-variable/translation-key ?k])] (d/db conn) eid))
+          [?e :group-variable/translation-key ?k])] (ds/unwrap-db db) eid))
 
 (defn t-key->uuid
-  "Get the :bp/uuid using translation-key"
-  [conn t]
-  (when-let [e (or (d/entity (ds/unwrap-db conn) [:group-variable/translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:group-variable/result-translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:subtool-variable/translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:group/translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:module/translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:tag-set/translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:tag/translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:color-tag/translation-key t])
-                   (d/entity (ds/unwrap-db conn) [:search-table/translation-key t])
-                   (submodule conn t))]
-    (:bp/uuid (d/touch e))))
+  "Get the :bp/uuid using translation-key. Accepts a Datomic conn or db."
+  [db t]
+  (let [db (ds/unwrap-db db)]
+    (when-let [e (or (d/entity db [:group-variable/translation-key t])
+                     (d/entity db [:group-variable/result-translation-key t])
+                     (d/entity db [:subtool-variable/translation-key t])
+                     (d/entity db [:group/translation-key t])
+                     (d/entity db [:module/translation-key t])
+                     (d/entity db [:tag-set/translation-key t])
+                     (d/entity db [:tag/translation-key t])
+                     (d/entity db [:color-tag/translation-key t])
+                     (d/entity db [:search-table/translation-key t])
+                     (submodule db t))]
+      (:bp/uuid (d/touch e)))))
 
 (defn t-key->entity
-  "Get the datomic entity given a translation-key"
-  [conn t]
-  (d/entity (ds/unwrap-db conn) [:bp/uuid (t-key->uuid conn t)]))
+  "Get the datomic entity given a translation-key. Accepts a Datomic conn or db."
+  [db t]
+  (d/entity (ds/unwrap-db db) [:bp/uuid (t-key->uuid db t)]))
 
 (defn t-key->eid
-  "Get the db/id using translation-key"
-  [conn t]
-  (:db/id (t-key->entity conn t)))
+  "Get the db/id using translation-key. Accepts a Datomic conn or db."
+  [db t]
+  (:db/id (t-key->entity db t)))
 
 (defn t-key->bp-uuid
-  "Get the db/id using translation-key"
-  [conn t]
-  (:bp/uuid (t-key->entity conn t)))
+  "Get the :bp/uuid using translation-key. Accepts a Datomic conn or db."
+  [db t]
+  (:bp/uuid (t-key->entity db t)))
 
 (defn t-key-action-name->eid
-  "Given a translation-key of a group-variable an action's name return the action's entity id"
-  [conn gv-t-key action-name]
-  (let [entity (t-key->entity conn gv-t-key)]
+  "Given a translation-key of a group-variable an action's name return the action's entity id.
+   Accepts a Datomic conn or db."
+  [db gv-t-key action-name]
+  (let [entity (t-key->entity db gv-t-key)]
     (->> (filter #(= (:action/name %) action-name)
                  (:group-variable/actions entity))
          first
          :db/id)))
 
 (defn bp6-code->variable-eid
-  "Given a Behave6 Variable code (e.g. `vSurfaceFuelCode`), returns the matching variable entity ID."
-  [conn bp6-code]
+  "Given a Behave6 Variable code (e.g. `vSurfaceFuelCode`), returns the matching variable entity ID.
+   Accepts a Datomic conn or db."
+  [db bp6-code]
   (d/q '[:find ?e .
          :in $ ?bp6-code
          :where [?e :variable/bp6-code ?bp6-code]]
-       (d/db conn)
+       (ds/unwrap-db db)
        bp6-code))
 
 (defn make-attr-is-component-payload
-  "Returns a payload for updating a given attribute to include :db/isComponent true"
-  [conn attr]
+  "Returns a payload for updating a given attribute to include :db/isComponent true.
+   Accepts a Datomic conn or db."
+  [db attr]
   (when-let [eid (d/q '[:find ?e .
                         :in $ ?attr
                         :where [?e :db/ident ?attr]]
-                      (ds/unwrap-db conn)
+                      (ds/unwrap-db db)
                       attr)]
     {:db/id          eid
      :db/isComponent true}))
 
 (defn make-attr-is-component!
   [conn attr]
-  (ds/transact conn [(make-attr-is-component-payload conn attr)]))
+  (ds/transact conn [(make-attr-is-component-payload (d/db conn) attr)]))
 
 (defn rollback-tx!
   "Given a transaction ID or a transaction result (return from datomic.api/transact), Reassert
@@ -263,12 +275,14 @@
   translation entities as well as adding these refs to the exisitng Enlgish language entity.
   `eid-start` is optional and will be used as the starting eid for the
   translation entities (prevents eid overlap if you wish to include this payload
-  in the same transaction where you've manually assigned :db/id). "
-  ([conn t-key->translation-map]
-   (build-translations-payload conn 0 t-key->translation-map))
+  in the same transaction where you've manually assigned :db/id).
+  Accepts a Datomic conn or db."
+  ([db t-key->translation-map]
+   (build-translations-payload db 0 t-key->translation-map))
 
-  ([conn eid-start t-key->translation-map]
-   (let [translations              (map-indexed (fn [idx [t-key translation]]
+  ([db eid-start t-key->translation-map]
+   (let [realized-db               (ds/unwrap-db db)
+         translations              (map-indexed (fn [idx [t-key translation]]
                                                   {:db/id                   (-> idx
                                                                                 inc
                                                                                 (+ eid-start)
@@ -280,21 +294,23 @@
                                           :in $
                                           :where
                                           [?e :language/name "English"]]
-                                        (d/db conn))
+                                        realized-db)
          language-translation-refs {:db/id                english-language-eid
                                     :language/translation (map :db/id translations)}]
      (into [language-translation-refs]
            translations))))
 
 (defn update-translations-payload
-  "Creates a payload to update existing translations for specific language shortcode."
-  [conn shortcode translation-map]
-  (let [language-eid
+  "Creates a payload to update existing translations for specific language shortcode.
+   Accepts a Datomic conn or db."
+  [db shortcode translation-map]
+  (let [realized-db                               (ds/unwrap-db db)
+        language-eid
         (d/q '[:find ?e .
                :in $ ?shortcode
                :where
                [?e :language/shortcode ?shortcode]]
-             (d/db conn) shortcode)
+             realized-db shortcode)
         query-translation-eid
         (fn [language-eid t-key]
           (d/q '[:find ?t .
@@ -302,22 +318,22 @@
                  :where
                  [?lang :language/translation ?t]
                  [?t :translation/key ?t-key]]
-               (d/db conn) language-eid t-key))]
+               realized-db language-eid t-key))]
     (map (fn [[t-key translation]]
            {:db/id                   (query-translation-eid language-eid t-key)
             :translation/translation translation}) translation-map)))
 
 (defn remove-nested-i18ns-tx
   "Removes an entity (and it's components), along with all nested
-   translation keys."
-  [conn t-key]
+   translation keys. Accepts a Datomic conn or db."
+  [db t-key]
   (let [i18ns (d/q '[:find [?e ...]
                      :in $ ?t-key
                      :where
                      [?e :translation/key ?key]
                      (or
                       [(= ?key ?t-key)]
-                      [(clojure.string/starts-with? ?key ?t-key)])] (d/db conn) t-key)]
+                      [(clojure.string/starts-with? ?key ?t-key)])] (ds/unwrap-db db) t-key)]
 
     (map (fn [eid] [:db/retractEntity eid]) i18ns)))
 
@@ -348,8 +364,8 @@
    :conditional/values   values})
 
 (defn ->conditional
-  "Payload for a Conditional."
-  [conn {:keys [ttype operator values group-variable-uuid sub-conditional-operator sub-conditionals] :as params}]
+  "Payload for a Conditional. Accepts a Datomic conn or db."
+  [db {:keys [ttype operator values group-variable-uuid sub-conditional-operator sub-conditionals] :as params}]
   (let [payload (cond-> {}
                   (nil? (:bp/uuid params)) (assoc :bp/uuid  (rand-uuid))
                   (nil? (:bp/nid params))  (assoc :bp/nid  (nano-id))
@@ -361,14 +377,14 @@
                   operator                 (assoc :conditional/operator operator)
                   values                   (assoc :conditional/values values)
                   sub-conditional-operator (assoc :conditional/sub-conditional-operator sub-conditional-operator)
-                  (seq sub-conditionals)   (assoc :conditional/sub-conditionals (map #(->conditional conn %) sub-conditionals)))]
+                  (seq sub-conditionals)   (assoc :conditional/sub-conditionals (map #(->conditional db %) sub-conditionals)))]
     (if (spec/valid? :behave/conditional payload)
       payload
       (spec/explain :behave/conditional payload))))
 
 (defn ->action
-  "Payload for an Action."
-  [conn {:keys [nname ttype target-value conditionals conditionals-operator] :as params}]
+  "Payload for an Action. Accepts a Datomic conn or db."
+  [db {:keys [nname ttype target-value conditionals conditionals-operator] :as params}]
   (let [payload (cond-> {}
                   (nil? (:bp/uuid params)) (assoc :bp/uuid  (rand-uuid))
                   (not  (:bp/nid params))  (assoc :bp/nid  (nano-id))
@@ -379,14 +395,14 @@
                   ttype                    (assoc :action/type ttype)
                   target-value             (assoc :action/target-value target-value)
                   conditionals-operator (assoc :action/conditionals-operator conditionals-operator)
-                  conditionals             (assoc :action/conditionals (map #(->conditional conn %) conditionals)))]
+                  conditionals             (assoc :action/conditionals (map #(->conditional db %) conditionals)))]
     (if (spec/valid? :behave/action payload)
       payload
       (spec/explain :behave/action payload))))
 
 (defn ->variable
-  [_conn {:keys [nname domain-uuid list-eid translation-key help-key kind bp6-label bp6-code map-units-convertible?
-                 dimension-uuid native-unit-uuid metric-unit-uuid english-unit-uuid]                                :as params}]
+  [_db {:keys [nname domain-uuid list-eid translation-key help-key kind bp6-label bp6-code map-units-convertible?
+               dimension-uuid native-unit-uuid metric-unit-uuid english-unit-uuid]                                :as params}]
   (let [payload (cond-> {}
                   (nil? (:bp/uuid params)) (assoc :bp/uuid (rand-uuid))
                   (not  (:bp/nid params))  (assoc :bp/nid  (nano-id))
@@ -411,10 +427,10 @@
       (spec/explain :behave/variable payload))))
 
 (defn ->group-variable
-  "Payload for a new Group Variable."
-  [conn {:keys
-         [parent-group-eid order variable-eid  cpp-namespace cpp-class cpp-function cpp-parameter translation-key conditionally-set? actions
-          hide-result-conditionals hide-result? disable-multi-valued-input-conditionals disable-multi-valued-input-conditional-operator direction-variables] :as params}]
+  "Payload for a new Group Variable. Accepts a Datomic conn or db."
+  [db {:keys
+       [parent-group-eid order variable-eid  cpp-namespace cpp-class cpp-function cpp-parameter translation-key conditionally-set? actions
+        hide-result-conditionals hide-result? disable-multi-valued-input-conditionals disable-multi-valued-input-conditional-operator direction-variables] :as params}]
   (let [payload (if (spec/valid? :behave/group-variable params)
                   params
                   (cond-> {}
@@ -426,27 +442,27 @@
                     parent-group-eid                                (assoc :group/_group-variables parent-group-eid)
                     order                                           (assoc :group-variable/order order)
                     variable-eid                                    (assoc :variable/_group-variables variable-eid)
-                    cpp-namespace                                   (assoc :group-variable/cpp-namespace (cpp-ns->uuid conn cpp-namespace))
-                    cpp-class                                       (assoc :group-variable/cpp-class (cpp-class->uuid conn cpp-namespace cpp-class))
-                    cpp-function                                    (assoc :group-variable/cpp-function (cpp-fn->uuid conn cpp-namespace cpp-class cpp-function))
-                    cpp-parameter                                   (assoc :group-variable/cpp-parameter (cpp-param->uuid conn cpp-namespace cpp-class cpp-function cpp-parameter))
+                    cpp-namespace                                   (assoc :group-variable/cpp-namespace (cpp-ns->uuid db cpp-namespace))
+                    cpp-class                                       (assoc :group-variable/cpp-class (cpp-class->uuid db cpp-namespace cpp-class))
+                    cpp-function                                    (assoc :group-variable/cpp-function (cpp-fn->uuid db cpp-namespace cpp-class cpp-function))
+                    cpp-parameter                                   (assoc :group-variable/cpp-parameter (cpp-param->uuid db cpp-namespace cpp-class cpp-function cpp-parameter))
                     (seq direction-variables)                       (assoc :group-variable/direction-variables direction-variables)
                     translation-key                                 (assoc :group-variable/translation-key translation-key)
                     translation-key                                 (assoc :group-variable/result-translation-key (s/replace translation-key ":output:" ":result:"))
                     translation-key                                 (assoc :group-variable/help-key (str translation-key ":help"))
                     conditionally-set?                              (assoc :group-variable/conditionally-set? conditionally-set?)
-                    (seq actions)                                   (assoc :group-variable/actions (map #(cond->> % (map? %) (->action conn)) actions))
+                    (seq actions)                                   (assoc :group-variable/actions (map #(cond->> % (map? %) (->action db)) actions))
                     hide-result?                                    (assoc :group-variable/hide-result? hide-result?)
-                    (seq hide-result-conditionals)                  (assoc :group-variable/hide-result-conditionals (map #(cond->> % (map? %) (->conditional conn)) hide-result-conditionals))
+                    (seq hide-result-conditionals)                  (assoc :group-variable/hide-result-conditionals (map #(cond->> % (map? %) (->conditional db)) hide-result-conditionals))
                     disable-multi-valued-input-conditional-operator (assoc :group-variable/disable-multi-valued-input-conditional-operator disable-multi-valued-input-conditional-operator)
-                    (seq disable-multi-valued-input-conditionals)   (assoc :group-variable/disable-multi-valued-input-conditionals (map #(cond->> % (map? %) (->conditional conn)) disable-multi-valued-input-conditionals))))]
+                    (seq disable-multi-valued-input-conditionals)   (assoc :group-variable/disable-multi-valued-input-conditionals (map #(cond->> % (map? %) (->conditional db)) disable-multi-valued-input-conditionals))))]
     (if (spec/valid? :behave/group-variable payload)
       payload
       (spec/explain :behave/group-variable payload))))
 
 (defn ->group
-  "Payload for a new Group."
-  [conn {:keys [parent-submodule-eid parent-group-eid group-name order translation-key conditionals group-variables subgroups research? hidden?] :as params}]
+  "Payload for a new Group. Accepts a Datomic conn or db."
+  [db {:keys [parent-submodule-eid parent-group-eid group-name order translation-key conditionals group-variables subgroups research? hidden?] :as params}]
   (let [payload (if (spec/valid? :behave/group params)
                   params
                   (cond-> {}
@@ -462,9 +478,9 @@
                     translation-key          (assoc :group/translation-key translation-key)
                     translation-key          (assoc :group/result-translation-key (s/replace translation-key ":output:" ":result:"))
                     translation-key          (assoc :group/help-key (str translation-key ":help"))
-                    (seq conditionals)       (assoc :group/conditionals (map #(cond->> % (map? %) (->conditional conn)) conditionals))
-                    (seq group-variables)    (assoc :group/group-variables (map #(cond->> % (map? %) (->group-variable conn)) group-variables))
-                    (seq subgroups)          (assoc :group/children (map #(cond->> % (map? %) (->group conn)) subgroups))
+                    (seq conditionals)       (assoc :group/conditionals (map #(cond->> % (map? %) (->conditional db)) conditionals))
+                    (seq group-variables)    (assoc :group/group-variables (map #(cond->> % (map? %) (->group-variable db)) group-variables))
+                    (seq subgroups)          (assoc :group/children (map #(cond->> % (map? %) (->group db)) subgroups))
                     research?                (assoc :group/research? research?)
                     hidden?                  (assoc :group/hidden? hidden?)))]
     (if (spec/valid? :behave/group payload)
@@ -472,8 +488,8 @@
       (spec/explain :behave/group payload))))
 
 (defn ->submodule
-  "Payload for a Submdoule"
-  [conn {:keys [io submodule-name order groups research? translation-key conditionals conditionals-operator] :as params}]
+  "Payload for a Submdoule. Accepts a Datomic conn or db."
+  [db {:keys [io submodule-name order groups research? translation-key conditionals conditionals-operator] :as params}]
   (let [payload (if (spec/valid? :behave/submodule params)
                   params
                   (cond-> {}
@@ -485,8 +501,8 @@
                     io                       (assoc :submodule/io io)
                     submodule-name           (assoc :submodule/name submodule-name)
                     order                    (assoc :submodule/order order)
-                    (seq groups)             (assoc :submodule/groups (map #(cond->> % (map? %) (->group conn)) groups))
-                    (seq conditionals)       (assoc :submodule/conditionals (map #(cond->> % (map? %) (->conditional conn)) conditionals))
+                    (seq groups)             (assoc :submodule/groups (map #(cond->> % (map? %) (->group db)) groups))
+                    (seq conditionals)       (assoc :submodule/conditionals (map #(cond->> % (map? %) (->conditional db)) conditionals))
                     conditionals-operator    (assoc :submodule/conditionals-operator conditionals-operator)
                     translation-key          (assoc :submodule/translation-key translation-key)
                     translation-key          (assoc :submodule/help-key (str translation-key ":help"))

--- a/components/schema_migrate/src/schema_migrate/interface.clj
+++ b/components/schema_migrate/src/schema_migrate/interface.clj
@@ -2,66 +2,66 @@
   (:require [schema-migrate.core   :as c]
             [schema-migrate.runner :as r]))
 
-(def ^{:arglists '([conn attr nname])
-       :doc      "Get the :bp/uuid using the name for the specified name attribute"}
+(def ^{:arglists '([db attr nname])
+       :doc      "Get the :bp/uuid using the name for the specified name attribute. Accepts a Datomic conn or db."}
   name->uuid c/name->uuid)
 
-(def ^{:arglists '([conn attr nname])
-       :doc      "Get the :bp/nid using the name for the specified name attribute"}
+(def ^{:arglists '([db attr nname])
+       :doc      "Get the :bp/nid using the name for the specified name attribute. Accepts a Datomic conn or db."}
   name->nid c/name->nid)
 
-(def ^{:arglists '([conn attr nname])
+(def ^{:arglists '([db attr nname])
        :doc      "Get the datomic entity id given the attribute and name. May not work as expected
-                  if attr and name is not unique."}
+                  if attr and name is not unique. Accepts a Datomic conn or db."}
   name->eid c/name->eid)
 
-(def ^{:arglists '([conn nname])
-       :doc      "Get the :bp/uuid using the cpp namepsace name"}
+(def ^{:arglists '([db nname])
+       :doc      "Get the :bp/uuid using the cpp namepsace name. Accepts a Datomic conn or db."}
   cpp-ns->uuid c/cpp-ns->uuid)
 
-(def ^{:arglists '([conn nnamespace cclass])
-       :doc      "Get the :bp/uuid using the cpp class name"}
+(def ^{:arglists '([db nnamespace cclass])
+       :doc      "Get the :bp/uuid using the cpp class name. Accepts a Datomic conn or db."}
   cpp-class->uuid c/cpp-class->uuid)
 
-(def ^{:arglists '([conn nnamespace cclass fn-name])
-       :doc      "Get the :bp/uuid using the cpp function name"}
+(def ^{:arglists '([db nnamespace cclass fn-name])
+       :doc      "Get the :bp/uuid using the cpp function name. Accepts a Datomic conn or db."}
   cpp-fn->uuid c/cpp-fn->uuid)
 
-(def ^{:arglists '([conn m])
+(def ^{:arglists '([db m])
        :doc      "Given a map of with the names of a namespace, class and function, return a map
-                   that resolves the names to a uuid. Requires all three names."}
+                   that resolves the names to a uuid. Requires all three names. Accepts a Datomic conn or db."}
   cpp-uuids c/cpp-uuids)
 
-(def ^{:arglists '([conn nnamespace cclass fn-name param-name])
-       :doc      "Get the :bp/uuid using the cpp function name and parameter name."}
+(def ^{:arglists '([db nnamespace cclass fn-name param-name])
+       :doc      "Get the :bp/uuid using the cpp function name and parameter name. Accepts a Datomic conn or db."}
   cpp-param->uuid c/cpp-param->uuid)
 
-(def ^{:arglists '([conn eid])
-       :doc      "Returns an entity's translation key."}
+(def ^{:arglists '([db eid])
+       :doc      "Returns an entity's translation key. Accepts a Datomic conn or db."}
   eid->t-key c/eid->t-key)
 
-(def ^{:arglists '([conn t])
-       :doc      "Get the :bp/uuid using translation-key"}
+(def ^{:arglists '([db t])
+       :doc      "Get the :bp/uuid using translation-key. Accepts a Datomic conn or db."}
   t-key->uuid c/t-key->uuid)
 
-(def ^{:arglists '([conn t])
-       :doc      "Get the datomic entity using translation-key"}
+(def ^{:arglists '([db t])
+       :doc      "Get the datomic entity using translation-key. Accepts a Datomic conn or db."}
   t-key->entity c/t-key->entity)
 
-(def ^{:arglists '([conn t])
-       :doc      "Get the :db/id using translation-key"}
+(def ^{:arglists '([db t])
+       :doc      "Get the :db/id using translation-key. Accepts a Datomic conn or db."}
   t-key->eid c/t-key->eid)
 
-(def ^{:arglists '([conn t])
-       :doc      "Get the :bp/uuid using translation-key"}
+(def ^{:arglists '([db t])
+       :doc      "Get the :bp/uuid using translation-key. Accepts a Datomic conn or db."}
   t-key->bp-uuid c/t-key->bp-uuid)
 
-(def ^{:arglists '([conn t])
-       :doc      "Given a translation-key of a group-variable an action's name return the action's entity id"}
+(def ^{:arglists '([db t])
+       :doc      "Given a translation-key of a group-variable an action's name return the action's entity id. Accepts a Datomic conn or db."}
   t-key-action-name->eid c/t-key-action-name->eid)
 
-(def ^{:arglists '([conn bp6-code])
-       :doc      "Given a Behave6 Variable code (e.g. `vSurfaceFuelCode`), returns the matching variable entity ID."}
+(def ^{:arglists '([db bp6-code])
+       :doc      "Given a Behave6 Variable code (e.g. `vSurfaceFuelCode`), returns the matching variable entity ID. Accepts a Datomic conn or db."}
   bp6-code->variable-eid c/bp6-code->variable-eid)
 
 (def ^{:arglists '([conn attr])
@@ -69,8 +69,8 @@
                   Takes a datahike conn."}
   make-attr-is-component! c/make-attr-is-component!)
 
-(def ^{:arglists '([conn attr])
-       :doc      "Returns the payload for making a schema attribute a \"Component\""}
+(def ^{:arglists '([db attr])
+       :doc      "Returns the payload for making a schema attribute a \"Component\". Accepts a Datomic conn or db."}
   make-attr-is-component-payload c/make-attr-is-component-payload)
 
 (def ^{:arglists '([conn tx])
@@ -83,20 +83,20 @@
        :doc      "Postwalk over data and insert bp/uuid and bp/nid into every map form"}
   postwalk-insert c/postwalk-insert)
 
-(def ^{:arglists '([conn eid-start t-key->translation-map])
+(def ^{:arglists '([db t-key->translation-map] [db eid-start t-key->translation-map])
        :doc      "Given a map of translation-key to it's translation create a payload that creates these
                   translation entities as well as adding these refs to the exisitng Enlgish language
                   entity. `eid-start` is optional and will be used as the starting eid for the
                   translation entities (prevents eid overlap if you wish to include this payload in
-                  the same transaction where you've manually assigned :db/id)."}
+                  the same transaction where you've manually assigned :db/id). Accepts a Datomic conn or db."}
   build-translations-payload c/build-translations-payload)
 
-(def ^{:arglists '([conn shortcode t-key->translation-map])
-       :doc      "Creates a payload to update existing translations for specific language shortcode."}
+(def ^{:arglists '([db shortcode t-key->translation-map])
+       :doc      "Creates a payload to update existing translations for specific language shortcode. Accepts a Datomic conn or db."}
   update-translations-payload c/update-translations-payload)
 
-(def ^{:arglists '([conn t-key])
-       :doc      "Removes an entity's (and it's components) translation keys."}
+(def ^{:arglists '([db t-key])
+       :doc      "Removes an entity's (and it's components) translation keys. Accepts a Datomic conn or db."}
   remove-nested-i18ns-tx c/remove-nested-i18ns-tx)
 
 (def ^{:arglists '([data])
@@ -111,24 +111,24 @@
        :doc      "Payload for a Module Conditional."}
   ->module-conditional c/->module-conditional)
 
-(def ^{:arglists '([conn params])
-       :doc      "Payload for a Conditional."}
+(def ^{:arglists '([db params])
+       :doc      "Payload for a Conditional. Accepts a Datomic conn or db."}
   ->conditional c/->conditional)
 
-(def ^{:arglists '([conn params])
-       :doc      "Payload for a new Group."}
+(def ^{:arglists '([db params])
+       :doc      "Payload for a new Group. Accepts a Datomic conn or db."}
   ->group c/->group)
 
-(def ^{:arglists '([conn params])
-       :doc      "Payload for an Action."}
+(def ^{:arglists '([db params])
+       :doc      "Payload for an Action. Accepts a Datomic conn or db."}
   ->action c/->action)
 
-(def ^{:arglists '([conn params])
-       :doc      "Payload for a new Variable."}
+(def ^{:arglists '([db params])
+       :doc      "Payload for a new Variable. Accepts a Datomic conn or db."}
   ->variable c/->variable)
 
-(def ^{:arglists '([conn params])
-       :doc      "Payload for a new Group Variable."}
+(def ^{:arglists '([db params])
+       :doc      "Payload for a new Group Variable. Accepts a Datomic conn or db."}
   ->group-variable c/->group-variable)
 
 (def ^{:arglists '([source-eid destination-eid])

--- a/components/schema_migrate/src/schema_migrate/runner.clj
+++ b/components/schema_migrate/src/schema_migrate/runner.clj
@@ -2,8 +2,8 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string  :as str]
-   [datomic.api     :as d]
    [datomic-store.main :as ds]
+   [datomic.api     :as d]
    [schema-migrate.core :as core]))
 
 (defn migration-applied?
@@ -65,7 +65,9 @@
    Each migration must export one of:
    - `payload-fn`    — a function of `conn` returning transaction data
    - `payload`       — a def containing transaction data
-   - `payload-steps` — a vector of functions or payloads, executed in order"
+   - `payload-steps` — a vector of `(fn [conn db] tx-data)` functions executed
+                       in order; each receives a fresh `db` snapshot reflecting
+                       all prior steps in the same migration"
   [dir]
   (->> (io/file dir)
        (.listFiles)
@@ -96,13 +98,17 @@
   (ds/transact conn (concat payload [marker])))
 
 (defn- run-multi-step!
-  "Transact each step in order. If any step fails, roll back all
-   previously completed steps in reverse order, then re-throw."
+  "Transact each step in order. Each step must be `(fn [conn db] tx-data)`;
+   `db` is a fresh snapshot taken after the prior step commits, so step N
+   sees all writes from step N-1. If any step fails, roll back all previously
+   completed steps in reverse order, then re-throw."
   [conn steps marker]
   (let [completed (atom [])]
     (try
       (doseq [step steps]
-        (let [payload (resolve-payload step conn)
+        (assert (fn? step) "payload-steps entries must be (fn [conn db] tx-data)")
+        (let [db        (d/db conn)
+              payload   (step conn db)
               tx-result (ds/transact conn payload)]
           (swap! completed conj tx-result)))
       ;; All steps succeeded — record the migration marker

--- a/components/schema_migrate/src/schema_migrate/runner.clj
+++ b/components/schema_migrate/src/schema_migrate/runner.clj
@@ -8,11 +8,11 @@
 
 (defn migration-applied?
   "Check if a migration has already been applied."
-  [conn migration-id]
+  [db migration-id]
   (some? (d/q '[:find ?e .
                 :in $ ?id
                 :where [?e :bp/migration-id ?id]]
-              (d/db conn) migration-id)))
+              db migration-id)))
 
 (defn- clj-file? [^java.io.File f]
   (and (.isFile f)
@@ -63,9 +63,9 @@
    effects in ignored migrations never fire.
 
    Each migration must export one of:
-   - `payload-fn`    — a function of `conn` returning transaction data
+   - `payload-fn`    — a function of `db` returning transaction data
    - `payload`       — a def containing transaction data
-   - `payload-steps` — a vector of `(fn [conn db] tx-data)` functions executed
+   - `payload-steps` — a vector of `(fn [db] tx-data)` functions executed
                        in order; each receives a fresh `db` snapshot reflecting
                        all prior steps in the same migration"
   [dir]
@@ -89,8 +89,8 @@
 
 (defn- resolve-payload
   "Resolve a payload value — call it if it's a function, otherwise return as-is."
-  [p conn]
-  (if (fn? p) (p conn) p))
+  [p db]
+  (if (fn? p) (p db) p))
 
 (defn- run-single-step!
   "Transact a single payload with a migration marker. Returns the tx result."
@@ -98,7 +98,7 @@
   (ds/transact conn (concat payload [marker])))
 
 (defn- run-multi-step!
-  "Transact each step in order. Each step must be `(fn [conn db] tx-data)`;
+  "Transact each step in order. Each step must be `(fn [db] tx-data)`;
    `db` is a fresh snapshot taken after the prior step commits, so step N
    sees all writes from step N-1. If any step fails, roll back all previously
    completed steps in reverse order, then re-throw."
@@ -106,9 +106,9 @@
   (let [completed (atom [])]
     (try
       (doseq [step steps]
-        (assert (fn? step) "payload-steps entries must be (fn [conn db] tx-data)")
+        (assert (fn? step) "payload-steps entries must be (fn [db] tx-data)")
         (let [db        (d/db conn)
-              payload   (step conn db)
+              payload   (step db)
               tx-result (ds/transact conn payload)]
           (swap! completed conj tx-result)))
       ;; All steps succeeded — record the migration marker
@@ -128,18 +128,19 @@
   [conn dir]
   (let [migrations (discover-migrations dir)]
     (doseq [{:keys [id payload-var steps-var]} migrations]
-      (cond
-        (migration-applied? conn id)
-        nil
+      (let [db (d/db conn)]
+        (cond
+          (migration-applied? db id)
+          nil
 
-        (and (nil? payload-var) (nil? steps-var))
-        (println "Skipping" id "— no payload-fn, payload, or payload-steps defined")
+          (and (nil? payload-var) (nil? steps-var))
+          (println "Skipping" id "— no payload-fn, payload, or payload-steps defined")
 
-        :else
-        (do (println "Running migration:" id)
-            (let [marker (core/->migration id)]
-              (if steps-var
-                (run-multi-step! conn @steps-var marker)
-                (let [payload (resolve-payload @payload-var conn)]
-                  (run-single-step! conn payload marker))))
-            (println "  Applied:" id))))))
+          :else
+          (do (println "Running migration:" id)
+              (let [marker (core/->migration id)]
+                (if steps-var
+                  (run-multi-step! conn @steps-var marker)
+                  (let [payload (resolve-payload @payload-var db)]
+                    (run-single-step! conn payload marker))))
+              (println "  Applied:" id)))))))

--- a/components/schema_migrate/test/schema_migrate/runner_test.clj
+++ b/components/schema_migrate/test/schema_migrate/runner_test.clj
@@ -88,7 +88,7 @@
         (is (runner/migration-applied? *conn* "migrations.2026-01-01-add-test-entity"))
         (is (= "hello"
                (d/q '[:find ?n .
-                       :where [?e :test/name ?n]]
+                      :where [?e :test/name ?n]]
                     (d/db *conn*))))))))
 
 (deftest single-step-payload-def-test
@@ -104,8 +104,8 @@
         (is (runner/migration-applied? *conn* "migrations.2026-01-01-static-payload"))
         (is (= 99
                (d/q '[:find ?v .
-                       :where [?e :test/name "static"]
-                              [?e :test/value ?v]]
+                      :where [?e :test/name "static"]
+                      [?e :test/value ?v]]
                     (d/db *conn*))))))))
 
 (deftest idempotency-test
@@ -122,7 +122,7 @@
         (runner/run-pending-migrations! *conn* (str dir))
         (is (= 1
                (d/q '[:find (count ?e) .
-                       :where [?e :test/name "once"]]
+                      :where [?e :test/name "once"]]
                     (d/db *conn*))))))))
 
 (deftest ignore-metadata-test
@@ -145,7 +145,7 @@
         (is (not (runner/migration-applied? *conn* "migrations.2026-01-01-ignored")))
         (is (runner/migration-applied? *conn* "migrations.2026-01-02-not-ignored"))
         (is (nil? (d/q '[:find ?e .
-                          :where [?e :test/name "should-not-exist"]]
+                         :where [?e :test/name "should-not-exist"]]
                        (d/db *conn*))))))))
 
 (deftest ordering-test
@@ -172,16 +172,16 @@
         :content  "(ns migrations.2026-01-01-multi-step)
 
 (def payload-steps
-  [(fn [conn] [{:test/name \"step1\" :test/value 1}])
-   (fn [conn] [{:test/name \"step2\" :test/value 2}])])
+  [(fn [conn db] [{:test/name \"step1\" :test/value 1}])
+   (fn [conn db] [{:test/name \"step2\" :test/value 2}])])
 "}]
       (fn [dir]
         (runner/run-pending-migrations! *conn* (str dir))
         (is (runner/migration-applied? *conn* "migrations.2026-01-01-multi-step"))
         (is (= 1 (d/q '[:find ?v . :where [?e :test/name "step1"] [?e :test/value ?v]]
-                       (d/db *conn*))))
+                      (d/db *conn*))))
         (is (= 2 (d/q '[:find ?v . :where [?e :test/name "step2"] [?e :test/value ?v]]
-                       (d/db *conn*))))))))
+                      (d/db *conn*))))))))
 
 (deftest multi-step-rollback-test
   (testing "When a step fails, previous steps are rolled back and marker is not recorded"
@@ -190,8 +190,8 @@
         :content  "(ns migrations.2026-01-01-multi-fail)
 
 (def payload-steps
-  [(fn [conn] [{:test/name \"will-rollback\" :test/value 1}])
-   (fn [conn] (throw (ex-info \"Step 2 failed\" {})))])
+  [(fn [conn db] [{:test/name \"will-rollback\" :test/value 1}])
+   (fn [conn db] (throw (ex-info \"Step 2 failed\" {})))])
 "}]
       (fn [dir]
         (is (thrown? Exception
@@ -199,8 +199,40 @@
         (is (not (runner/migration-applied? *conn* "migrations.2026-01-01-multi-fail")))
         ;; Step 1 should have been rolled back
         (is (nil? (d/q '[:find ?e .
-                          :where [?e :test/name "will-rollback"]]
+                         :where [?e :test/name "will-rollback"]]
                        (d/db *conn*))))))))
+
+(deftest multi-step-sees-prior-writes-test
+  (testing "Step N receives a db reflecting step N-1's committed writes"
+    (with-temp-migrations
+      [{:filename "2026_01_01_cross_step.clj"
+        :content  "(ns migrations.2026-01-01-cross-step
+  (:require [datomic.api :as d]))
+
+(def payload-steps
+  [(fn [conn db] [{:test/name \"marker\" :test/value 1}])
+   (fn [conn db]
+     (let [eid (d/q '[:find ?e . :where [?e :test/name \"marker\"]] db)]
+       [[:db/add eid :test/value 2]]))])
+"}]
+      (fn [dir]
+        (runner/run-pending-migrations! *conn* (str dir))
+        (is (runner/migration-applied? *conn* "migrations.2026-01-01-cross-step"))
+        (is (= 2 (d/q '[:find ?v . :where [?e :test/name "marker"] [?e :test/value ?v]]
+                      (d/db *conn*))))))))
+
+(deftest multi-step-rejects-non-fn-test
+  (testing "A raw vector as a payload-steps entry throws an assertion error"
+    (with-temp-migrations
+      [{:filename "2026_01_01_raw_vector_step.clj"
+        :content  "(ns migrations.2026-01-01-raw-vector-step)
+
+(def payload-steps
+  [[{:test/name \"raw\" :test/value 0}]])
+"}]
+      (fn [dir]
+        (is (thrown? AssertionError
+                     (runner/run-pending-migrations! *conn* (str dir))))))))
 
 (deftest halt-on-failure-test
   (testing "A failing migration halts execution — subsequent migrations don't run"
@@ -222,5 +254,5 @@
                      (runner/run-pending-migrations! *conn* (str dir))))
         (is (not (runner/migration-applied? *conn* "migrations.2026-01-02-should-not-run")))
         (is (nil? (d/q '[:find ?e .
-                          :where [?e :test/name "unreachable"]]
+                         :where [?e :test/name "unreachable"]]
                        (d/db *conn*))))))))

--- a/components/schema_migrate/test/schema_migrate/runner_test.clj
+++ b/components/schema_migrate/test/schema_migrate/runner_test.clj
@@ -80,12 +80,12 @@
         :content  "(ns migrations.2026-01-01-add-test-entity
   (:require [datomic.api :as d]))
 
-(defn payload-fn [conn]
+(defn payload-fn [db]
   [{:test/name \"hello\" :test/value 42}])
 "}]
       (fn [dir]
         (runner/run-pending-migrations! *conn* (str dir))
-        (is (runner/migration-applied? *conn* "migrations.2026-01-01-add-test-entity"))
+        (is (runner/migration-applied? (d/db *conn*) "migrations.2026-01-01-add-test-entity"))
         (is (= "hello"
                (d/q '[:find ?n .
                       :where [?e :test/name ?n]]
@@ -101,7 +101,7 @@
 "}]
       (fn [dir]
         (runner/run-pending-migrations! *conn* (str dir))
-        (is (runner/migration-applied? *conn* "migrations.2026-01-01-static-payload"))
+        (is (runner/migration-applied? (d/db *conn*) "migrations.2026-01-01-static-payload"))
         (is (= 99
                (d/q '[:find ?v .
                       :where [?e :test/name "static"]
@@ -114,7 +114,7 @@
       [{:filename "2026_01_01_idempotent.clj"
         :content  "(ns migrations.2026-01-01-idempotent)
 
-(defn payload-fn [conn]
+(defn payload-fn [db]
   [{:test/name \"once\" :test/value 1}])
 "}]
       (fn [dir]
@@ -131,19 +131,19 @@
       [{:filename "2026_01_01_ignored.clj"
         :content  "(ns ^{:migrate/ignore? true} migrations.2026-01-01-ignored)
 
-(defn payload-fn [conn]
+(defn payload-fn [db]
   [{:test/name \"should-not-exist\" :test/value 0}])
 "}
        {:filename "2026_01_02_not_ignored.clj"
         :content  "(ns migrations.2026-01-02-not-ignored)
 
-(defn payload-fn [conn]
+(defn payload-fn [db]
   [{:test/name \"should-exist\" :test/value 1}])
 "}]
       (fn [dir]
         (runner/run-pending-migrations! *conn* (str dir))
-        (is (not (runner/migration-applied? *conn* "migrations.2026-01-01-ignored")))
-        (is (runner/migration-applied? *conn* "migrations.2026-01-02-not-ignored"))
+        (is (not (runner/migration-applied? (d/db *conn*) "migrations.2026-01-01-ignored")))
+        (is (runner/migration-applied? (d/db *conn*) "migrations.2026-01-02-not-ignored"))
         (is (nil? (d/q '[:find ?e .
                          :where [?e :test/name "should-not-exist"]]
                        (d/db *conn*))))))))
@@ -154,16 +154,16 @@
       (with-temp-migrations
         [{:filename "2026_01_02_second.clj"
           :content  (str "(ns migrations.2026-01-02-second)\n"
-                         "(defn payload-fn [conn]\n"
+                         "(defn payload-fn [db]\n"
                          "  [{:test/name \"second\" :test/value 2}])\n")}
          {:filename "2026_01_01_first.clj"
           :content  (str "(ns migrations.2026-01-01-first)\n"
-                         "(defn payload-fn [conn]\n"
+                         "(defn payload-fn [db]\n"
                          "  [{:test/name \"first\" :test/value 1}])\n")}]
         (fn [dir]
           (runner/run-pending-migrations! *conn* (str dir))
-          (is (runner/migration-applied? *conn* "migrations.2026-01-01-first"))
-          (is (runner/migration-applied? *conn* "migrations.2026-01-02-second")))))))
+          (is (runner/migration-applied? (d/db *conn*) "migrations.2026-01-01-first"))
+          (is (runner/migration-applied? (d/db *conn*) "migrations.2026-01-02-second")))))))
 
 (deftest multi-step-success-test
   (testing "payload-steps migrations run all steps and record marker"
@@ -172,12 +172,12 @@
         :content  "(ns migrations.2026-01-01-multi-step)
 
 (def payload-steps
-  [(fn [conn db] [{:test/name \"step1\" :test/value 1}])
-   (fn [conn db] [{:test/name \"step2\" :test/value 2}])])
+  [(fn [db] [{:test/name \"step1\" :test/value 1}])
+   (fn [db] [{:test/name \"step2\" :test/value 2}])])
 "}]
       (fn [dir]
         (runner/run-pending-migrations! *conn* (str dir))
-        (is (runner/migration-applied? *conn* "migrations.2026-01-01-multi-step"))
+        (is (runner/migration-applied? (d/db *conn*) "migrations.2026-01-01-multi-step"))
         (is (= 1 (d/q '[:find ?v . :where [?e :test/name "step1"] [?e :test/value ?v]]
                       (d/db *conn*))))
         (is (= 2 (d/q '[:find ?v . :where [?e :test/name "step2"] [?e :test/value ?v]]
@@ -190,13 +190,13 @@
         :content  "(ns migrations.2026-01-01-multi-fail)
 
 (def payload-steps
-  [(fn [conn db] [{:test/name \"will-rollback\" :test/value 1}])
-   (fn [conn db] (throw (ex-info \"Step 2 failed\" {})))])
+  [(fn [db] [{:test/name \"will-rollback\" :test/value 1}])
+   (fn [db] (throw (ex-info \"Step 2 failed\" {})))])
 "}]
       (fn [dir]
         (is (thrown? Exception
                      (runner/run-pending-migrations! *conn* (str dir))))
-        (is (not (runner/migration-applied? *conn* "migrations.2026-01-01-multi-fail")))
+        (is (not (runner/migration-applied? (d/db *conn*) "migrations.2026-01-01-multi-fail")))
         ;; Step 1 should have been rolled back
         (is (nil? (d/q '[:find ?e .
                          :where [?e :test/name "will-rollback"]]
@@ -210,14 +210,14 @@
   (:require [datomic.api :as d]))
 
 (def payload-steps
-  [(fn [conn db] [{:test/name \"marker\" :test/value 1}])
-   (fn [conn db]
+  [(fn [db] [{:test/name \"marker\" :test/value 1}])
+   (fn [db]
      (let [eid (d/q '[:find ?e . :where [?e :test/name \"marker\"]] db)]
        [[:db/add eid :test/value 2]]))])
 "}]
       (fn [dir]
         (runner/run-pending-migrations! *conn* (str dir))
-        (is (runner/migration-applied? *conn* "migrations.2026-01-01-cross-step"))
+        (is (runner/migration-applied? (d/db *conn*) "migrations.2026-01-01-cross-step"))
         (is (= 2 (d/q '[:find ?v . :where [?e :test/name "marker"] [?e :test/value ?v]]
                       (d/db *conn*))))))))
 
@@ -240,19 +240,19 @@
       [{:filename "2026_01_01_fails.clj"
         :content  "(ns migrations.2026-01-01-fails)
 
-(defn payload-fn [conn]
+(defn payload-fn [db]
   (throw (ex-info \"Boom\" {})))
 "}
        {:filename "2026_01_02_should_not_run.clj"
         :content  "(ns migrations.2026-01-02-should-not-run)
 
-(defn payload-fn [conn]
+(defn payload-fn [db]
   [{:test/name \"unreachable\" :test/value 0}])
 "}]
       (fn [dir]
         (is (thrown? Exception
                      (runner/run-pending-migrations! *conn* (str dir))))
-        (is (not (runner/migration-applied? *conn* "migrations.2026-01-02-should-not-run")))
+        (is (not (runner/migration-applied? (d/db *conn*) "migrations.2026-01-02-should-not-run")))
         (is (nil? (d/q '[:find ?e .
                          :where [?e :test/name "unreachable"]]
                        (d/db *conn*))))))))

--- a/development/migrations/2026_05_19_always_enable_dead_fuel_moisture.clj
+++ b/development/migrations/2026_05_19_always_enable_dead_fuel_moisture.clj
@@ -1,4 +1,4 @@
-(ns migrations.2026-05-19-always-enable-dead-fuel-moisture
+(ns ^{:migrate/ignore? true} migrations.2026-05-19-always-enable-dead-fuel-moisture
   (:require [datomic.api :as d]
             [schema-migrate.interface :as sm]))
 
@@ -31,30 +31,31 @@
   "behaveplus:surface:output:spot:maximum_spotting_distance:wind_driven_surface_fire")
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(defn payload-fn [db]
-  (let [group-eid (d/q '[:find ?g .
-                         :in $ ?tk
-                         :where [?g :group/translation-key ?tk]]
-                       db group-t-key)
-        old-cond  (d/q '[:find ?c .
-                         :in $ ?group ?wd-tk
-                         :where
-                         [?group :group/conditionals ?c]
-                         [?wd :group-variable/translation-key ?wd-tk]
-                         [?wd :bp/uuid ?wd-uuid]
-                         [?c :conditional/group-variable-uuid ?wd-uuid]]
-                       db group-eid wind-driven-fuel-model-gv-t-key)
-        wdsf-uuid (d/q '[:find ?u .
-                         :in $ ?tk
-                         :where
-                         [?gv :group-variable/translation-key ?tk]
-                         [?gv :bp/uuid ?u]]
-                       db wdsf-output-gv-t-key)]
+(defn payload-fn [conn]
+  (let [db          (d/db conn)
+        group-eid   (d/q '[:find ?g .
+                           :in $ ?tk
+                           :where [?g :group/translation-key ?tk]]
+                         db group-t-key)
+        old-cond    (d/q '[:find ?c .
+                           :in $ ?group ?wd-tk
+                           :where
+                           [?group :group/conditionals ?c]
+                           [?wd :group-variable/translation-key ?wd-tk]
+                           [?wd :bp/uuid ?wd-uuid]
+                           [?c :conditional/group-variable-uuid ?wd-uuid]]
+                         db group-eid wind-driven-fuel-model-gv-t-key)
+        wdsf-uuid   (d/q '[:find ?u .
+                           :in $ ?tk
+                           :where
+                           [?gv :group-variable/translation-key ?tk]
+                           [?gv :bp/uuid ?u]]
+                         db wdsf-output-gv-t-key)]
     (cond-> []
       old-cond  (conj [:db/retractEntity old-cond])
       wdsf-uuid (into (let [tempid   -1
                             new-cond (-> (sm/->conditional
-                                          db
+                                          conn
                                           {:ttype               :group-variable
                                            :operator            :equal
                                            :values              ["true"]
@@ -77,7 +78,7 @@
   (def conn (store/default-conn))
 
   #_{:clj-kondo/ignore [:missing-docstring]}
-  (try (def tx-data @(d/transact conn (payload-fn (d/db conn))))
+  (try (def tx-data @(d/transact conn (payload-fn conn)))
        (catch Exception e (str "caught exception: " (.getMessage e)))))
 
 ;; ===========================================================================================================

--- a/development/migrations/2026_05_19_always_enable_dead_fuel_moisture.clj
+++ b/development/migrations/2026_05_19_always_enable_dead_fuel_moisture.clj
@@ -1,6 +1,6 @@
 (ns migrations.2026-05-19-always-enable-dead-fuel-moisture
-  (:require [schema-migrate.interface :as sm]
-            [datomic.api :as d]))
+  (:require [datomic.api :as d]
+            [schema-migrate.interface :as sm]))
 
 ;; ===========================================================================================================
 ;; Overview
@@ -31,31 +31,30 @@
   "behaveplus:surface:output:spot:maximum_spotting_distance:wind_driven_surface_fire")
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(defn payload-fn [conn]
-  (let [db          (d/db conn)
-        group-eid   (d/q '[:find ?g .
-                           :in $ ?tk
-                           :where [?g :group/translation-key ?tk]]
-                         db group-t-key)
-        old-cond    (d/q '[:find ?c .
-                           :in $ ?group ?wd-tk
-                           :where
-                           [?group :group/conditionals ?c]
-                           [?wd :group-variable/translation-key ?wd-tk]
-                           [?wd :bp/uuid ?wd-uuid]
-                           [?c :conditional/group-variable-uuid ?wd-uuid]]
-                         db group-eid wind-driven-fuel-model-gv-t-key)
-        wdsf-uuid   (d/q '[:find ?u .
-                           :in $ ?tk
-                           :where
-                           [?gv :group-variable/translation-key ?tk]
-                           [?gv :bp/uuid ?u]]
-                         db wdsf-output-gv-t-key)]
+(defn payload-fn [db]
+  (let [group-eid (d/q '[:find ?g .
+                         :in $ ?tk
+                         :where [?g :group/translation-key ?tk]]
+                       db group-t-key)
+        old-cond  (d/q '[:find ?c .
+                         :in $ ?group ?wd-tk
+                         :where
+                         [?group :group/conditionals ?c]
+                         [?wd :group-variable/translation-key ?wd-tk]
+                         [?wd :bp/uuid ?wd-uuid]
+                         [?c :conditional/group-variable-uuid ?wd-uuid]]
+                       db group-eid wind-driven-fuel-model-gv-t-key)
+        wdsf-uuid (d/q '[:find ?u .
+                         :in $ ?tk
+                         :where
+                         [?gv :group-variable/translation-key ?tk]
+                         [?gv :bp/uuid ?u]]
+                       db wdsf-output-gv-t-key)]
     (cond-> []
       old-cond  (conj [:db/retractEntity old-cond])
       wdsf-uuid (into (let [tempid   -1
                             new-cond (-> (sm/->conditional
-                                          conn
+                                          db
                                           {:ttype               :group-variable
                                            :operator            :equal
                                            :values              ["true"]
@@ -78,7 +77,7 @@
   (def conn (store/default-conn))
 
   #_{:clj-kondo/ignore [:missing-docstring]}
-  (try (def tx-data @(d/transact conn (payload-fn conn)))
+  (try (def tx-data @(d/transact conn (payload-fn (d/db conn))))
        (catch Exception e (str "caught exception: " (.getMessage e)))))
 
 ;; ===========================================================================================================

--- a/development/migrations/template.clj
+++ b/development/migrations/template.clj
@@ -1,6 +1,6 @@
 (ns migrations.template
-  (:require [schema-migrate.interface :as sm]
-            [datomic.api :as d]))
+  (:require [datomic.api :as d]
+            [schema-migrate.interface :as sm]))
 
 ;; ===========================================================================================================
 ;; Overview
@@ -21,13 +21,15 @@
   [])
 
 ;; Option B: Multi-step migration (uncomment and remove payload-fn above)
-;; Each step is a function of conn (or a raw payload vector).
+;; Each step is (fn [conn db] tx-data). The runner passes a fresh db snapshot
+;; taken after the prior step commits, so step N sees step N-1's writes.
+;; Use conn for sm/* helpers; use db for direct d/q / d/entity calls.
 ;; If any step fails, all previously completed steps are rolled back.
 ;;
 ;; #_{:clj-kondo/ignore [:missing-docstring]}
 ;; (def payload-steps
-;;   [(fn [conn] [{:db/id (sm/t-key->eid conn "behaveplus:...") :group/order 0}])
-;;    (fn [conn] [[:db/retractEntity (sm/t-key->eid conn "behaveplus:...")]])])
+;;   [(fn [conn db] [{:db/id (sm/t-key->eid conn "behaveplus:...") :group/order 0}])
+;;    (fn [conn db] [[:db/retractEntity (d/q '[:find ?e . :where ...] db)]])])
 
 ;; ===========================================================================================================
 ;; Manual REPL usage

--- a/development/migrations/template.clj
+++ b/development/migrations/template.clj
@@ -13,23 +13,22 @@
 ;; ===========================================================================================================
 
 ;; Option A: Single-step migration
-;; The runner calls (payload-fn conn) at startup.
+;; The runner calls (payload-fn db) at startup.
 ;; Return a vector of transaction data.
 
 #_{:clj-kondo/ignore [:missing-docstring]}
-(defn payload-fn [conn]
+(defn payload-fn [db]
   [])
 
 ;; Option B: Multi-step migration (uncomment and remove payload-fn above)
-;; Each step is (fn [conn db] tx-data). The runner passes a fresh db snapshot
+;; Each step is (fn [db] tx-data). The runner passes a fresh db snapshot
 ;; taken after the prior step commits, so step N sees step N-1's writes.
-;; Use conn for sm/* helpers; use db for direct d/q / d/entity calls.
 ;; If any step fails, all previously completed steps are rolled back.
 ;;
 ;; #_{:clj-kondo/ignore [:missing-docstring]}
 ;; (def payload-steps
-;;   [(fn [conn db] [{:db/id (sm/t-key->eid conn "behaveplus:...") :group/order 0}])
-;;    (fn [conn db] [[:db/retractEntity (d/q '[:find ?e . :where ...] db)]])])
+;;   [(fn [db] [{:db/id (sm/t-key->eid db "behaveplus:...") :group/order 0}])
+;;    (fn [db] [[:db/retractEntity (d/q '[:find ?e . :where ...] db)]])])
 
 ;; ===========================================================================================================
 ;; Manual REPL usage
@@ -43,7 +42,7 @@
   (def conn (behave-cms.store/default-conn))
 
   #_{:clj-kondo/ignore [:missing-docstring]}
-  (try (def tx-data @(d/transact conn (payload-fn conn)))
+  (try (def tx-data @(d/transact conn (payload-fn (d/db conn))))
        (catch Exception e (str "caught exception: " (.getMessage e)))))
 
 ;; ===========================================================================================================


### PR DESCRIPTION
## Purpose

- Refactor schema migration helpers to accept a realized db instead of conn (more idiomatic), but still maintains backward comparability with `(ds/unwrap-db db)`
- ensure each step `run-multi-step!` can have an updated db after a previous step is ran. This is achieved by ensuring each step is a function that accepts a db, as opposed to before which would also allow a vector of datoms. The vector of datoms would have been built on a stale db state at the beginning before the doseq on the steps.

## Related Issues

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

## Screenshots