### PR TITLE
[BHP1-1534] Adjust Group/Subgroups in Standard match Guided

### DIFF
--- a/projects/behave/resources/public/css/app-style.css
+++ b/projects/behave/resources/public/css/app-style.css
@@ -585,7 +585,6 @@ body {
   border-bottom: 2px solid var(--themed-header-bottom-border-color);
 }
 
-.wizard-group__header--standard,
 .wizard-graph__output-header,
 .wizard-group--level-1 > .wizard-group__header {
   padding: 5px 18px;
@@ -820,14 +819,26 @@ body {
 }
 
 .wizard-standard__submodule-header {
-  padding: 10px 0px 0px 0px;
+  padding: 5px 0px 5px 10px;
   border-bottom: 2px solid var(--gray-4);
   font-weight: var(--font-weight-bold);
   background-color: var(--themed-header-background-color);
 }
 
+.wizard-group__header--standard {
+  padding-left: 20px;
+}
 
+.wizard-group__header--standard.wizard-group__header--leaf {
+  padding-left: 20px;
+  font-weight: var(--font-weight-normal);
+  background-color: var(--lightblue-2);
+}
 
+.wizard-subgroup__indent .wizard-group__header--standard {
+  padding-left: 30px;
+  font-weight: var(--font-weight-normal);
+}
 
 /* -- End Wizard Standard -- */
 

--- a/projects/behave/src/cljs/behave/components/input_group.cljs
+++ b/projects/behave/src/cljs/behave/components/input_group.cljs
@@ -127,7 +127,7 @@
 (defmethod wizard-input :discrete [variable {:keys [ws-uuid]} group-uuid repeat-id repeat-group?]
   (r/with-let [{gv-uuid  :bp/uuid
                 help-key :group-variable/help-key
-                list     :variable/list} variable
+                v-list    :variable/list} variable
                selected                  (rf/subscribe [:worksheet/input-value ws-uuid group-uuid repeat-id gv-uuid])
                default-option            (rf/subscribe [:wizard/default-option ws-uuid gv-uuid])
                disabled-options          (rf/subscribe [:wizard/disabled-options ws-uuid gv-uuid])
@@ -135,7 +135,7 @@
                on-change                 #(upsert-input ws-uuid group-uuid repeat-id gv-uuid (input-value %))
                _                         (when (and (nil? @selected) @default-option)
                                            (upsert-input ws-uuid group-uuid repeat-id gv-uuid @default-option))
-               options                   (sort-by :list-option/order (filter #(not (:list-option/hide? %)) (:list/options list)))
+               options                   (sort-by :list-option/order (filter #(not (:list-option/hide? %)) (:list/options v-list)))
                num-options               (count options)
                ->option                  (fn [{value :list-option/value t-key :list-option/translation-key default? :list-option/default}]
                                            {:value     value

--- a/projects/behave/src/cljs/behave/components/input_group.cljs
+++ b/projects/behave/src/cljs/behave/components/input_group.cljs
@@ -298,9 +298,11 @@
   (let [variables (sort-by :group-variable/order variables)]
     [:div.wizard-group
      {:class (str "wizard-group--level-" level)}
-     [:div {:class [(if (= workflow :standard)
-                      "wizard-group__header--standard"
-                      "wizard-group__header")]}
+     [:div {:class ["wizard-group__header"
+                    (when (= workflow :standard)
+                      "wizard-group__header--standard")
+                    (when-not (seq (:group/children group))
+                      "wizard-group__header--leaf")]}
       @(<t (:group/translation-key group))]
      (if (:group/repeat? group)
        [repeat-group params group variables]

--- a/projects/behave/src/cljs/behave/components/output_group.cljs
+++ b/projects/behave/src/cljs/behave/components/output_group.cljs
@@ -43,9 +43,11 @@
 (defn output-group [{:keys [ws-uuid workflow]} group variables level]
   [:div.wizard-group
    {:class (str "wizard-group--level-" level)}
-   [:div {:class [(if (= workflow :standard)
-                    "wizard-group__header--standard"
-                    "wizard-group__header")]}
+   [:div {:class ["wizard-group__header"
+                  (when (= workflow :standard)
+                    "wizard-group__header--standard")
+                  (when-not (seq (:group/children group))
+                    "wizard-group__header--leaf")]}
     @(<t (:group/translation-key group))]
    [:div.wizard-group__outputs
     (if (:group/single-select? group)


### PR DESCRIPTION
## Purpose
Adjusts Submodules / Groups / Subgroups to ensure it's possible to
distinguish between the different levels. Creates both padding to
assume a more 'tree-like' structure. All "Leafs" are given identical
backgrounds to ensure consistency (see blue, that's an user input).

## Related Issues
Closes BHP1-1534

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open a new Standard Workflow with Surface & Crown
2. Verify that Groups are now colored with a border that match their
   Module (e.g. Orange for Contain, Green for Surface)
3. Select 'Rate of Spread' output, go to inputs
4. Verify that Fuel Model / Standard / Fuel Model show a tree-like
   indentation, and that Fuel Model subgroup is a blue background.

## Screenshots

<!-- Message of single commit: -->