### PR TITLE
[BHP1-1562] Replace Contain Elapsed Time with Fire Size at Report

### DIFF
--- a/components/schema_migrate/src/schema_migrate/core.clj
+++ b/components/schema_migrate/src/schema_migrate/core.clj
@@ -208,6 +208,20 @@
        (d/db conn)
        bp6-code))
 
+(defn find-link
+  "Find the link entity connecting two group-variables by translation key.
+   Returns the `:db/id` or `nil`. Links may also carry conditional attrs
+   (`:conditional/type`, `:conditional/operator`, `:conditional/values`)."
+  [conn src-t-key dst-t-key]
+  (d/q '[:find ?c .
+         :in $ ?src ?dst
+         :where
+         [?s :group-variable/translation-key ?src]
+         [?d :group-variable/translation-key ?dst]
+         [?c :link/source ?s]
+         [?c :link/destination ?d]]
+       (d/db conn) src-t-key dst-t-key))
+
 (defn make-attr-is-component-payload
   "Returns a payload for updating a given attribute to include :db/isComponent true"
   [conn attr]

--- a/components/schema_migrate/src/schema_migrate/interface.clj
+++ b/components/schema_migrate/src/schema_migrate/interface.clj
@@ -64,6 +64,13 @@
        :doc      "Given a Behave6 Variable code (e.g. `vSurfaceFuelCode`), returns the matching variable entity ID."}
   bp6-code->variable-eid c/bp6-code->variable-eid)
 
+(def ^{:arglists '([conn src-t-key dst-t-key])
+       :doc      "Find the link entity connecting two group-variables by
+                  translation key. Returns the :db/id or nil. Links may also
+                  carry conditional attrs (:conditional/type, :operator,
+                  :values)."}
+  find-link c/find-link)
+
 (def ^{:arglists '([conn attr])
        :doc      "Sets :db/isComponent true for a given schema attribute.
                   Takes a datahike conn."}

--- a/development/migrations/2026_05_29_add_fire_size_at_report.clj
+++ b/development/migrations/2026_05_29_add_fire_size_at_report.clj
@@ -1,0 +1,106 @@
+(ns migrations.2026-05-29-add-fire-size-at-report
+  (:require [schema-migrate.interface :as sm]
+            [datomic.api :as d]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; BHP1-1562: Replace Contain's confusing "Elapsed Time" input with the
+;; existing-but-hidden "Fire Size at Report" input (acres, 0.1 - 100), and
+;; relocate it into the Suppression submodule where Elapsed Time used to
+;; live.
+;;
+;; Currently `behaveplus:contain:input:fire:fire_size_at_report:...` is hidden
+;; from the UI because a conditional link on the Contain > Fire submodule
+;; routes Surface's "Fire Area" output into it whenever module = "contain".
+;; The C++ ContainAdapter does not actually use Elapsed Time as an input — it
+;; derives initial elapsed time internally from the report size.
+;;
+;; Steps:
+;;   1. Retract the Surface > Fire Area → Contain > Fire Size at Report
+;;      conditional link so Fire Size at Report becomes a user input.
+;;   2. Detach the Elapsed Time group from Contain > Suppression.
+;;   3. Move the Fire Area at Report group out of Contain > Fire and into
+;;      Contain > Suppression at the slot Elapsed Time vacated (order 3).
+;;   4. Gate the Fire submodule on `:module := {"contain"}` so it only
+;;      appears when Contain is the only active module (its remaining
+;;      groups — Surface ROS Max and Length-to-Width Ratio — are otherwise
+;;      supplied by the Surface module).
+;;
+;; Surface > Size > Elapsed Time and Crown > Size > Elapsed Time are left
+;; untouched.
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+(def ^:private surface-fire-area-t-key
+  "behaveplus:surface:output:size:surface___fire_size:fire_area")
+
+(def ^:private contain-fire-size-t-key
+  "behaveplus:contain:input:fire:fire_size_at_report:fire_size_at_report")
+
+(def ^:private fire-submodule-t-key
+  "behaveplus:contain:input:fire")
+
+(def ^:private fire-size-at-report-group-t-key
+  "behaveplus:contain:input:fire:fire_size_at_report")
+
+(def ^:private suppression-submodule-t-key
+  "behaveplus:contain:input:suppression")
+
+(def ^:private elapsed-time-group-t-key
+  "behaveplus:contain:input:suppression:elapsed-time")
+
+(def ^:private fire-size-order
+  "Slot in Suppression that Elapsed Time used to occupy."
+  3)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defn payload-fn [conn]
+  (let [auto-link       (sm/find-link conn surface-fire-area-t-key contain-fire-size-t-key)
+        fire-submodule  (sm/t-key->eid conn fire-submodule-t-key)
+        suppression     (sm/t-key->eid conn suppression-submodule-t-key)
+        fire-size-group (sm/t-key->eid conn fire-size-at-report-group-t-key)
+        elapsed-group   (sm/t-key->eid conn elapsed-time-group-t-key)]
+    (cond-> []
+      auto-link
+      (conj [:db/retractEntity auto-link])
+
+      (and suppression elapsed-group)
+      (conj [:db/retract suppression :submodule/groups elapsed-group])
+
+      (and fire-submodule suppression fire-size-group)
+      (into [[:db/retract fire-submodule :submodule/groups fire-size-group]
+             [:db/add     suppression    :submodule/groups fire-size-group]
+             [:db/add     fire-size-group :group/order     fire-size-order]])
+
+      fire-submodule
+      (into (let [contain-only (-> (sm/->module-conditional :equal ["contain"])
+                                   (assoc :db/id -1))]
+              [contain-only
+               [:db/add fire-submodule :submodule/conditionals -1]])))))
+
+;; ===========================================================================================================
+;; Manual REPL usage
+;; ===========================================================================================================
+
+(comment
+  (require '[behave-cms.server :as cms]
+           '[behave-cms.store  :as store])
+  (cms/init-db!)
+
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (def conn (store/default-conn))
+
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (try (def tx-data @(d/transact conn (payload-fn conn)))
+       (catch Exception e (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; Rollback
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn tx-data))


### PR DESCRIPTION
## Purpose

BHP1-1562: Replace Contain's "Elapsed Time" input with the "Fire Size at Report" input, relocate it into the Suppression submodule where Elapsed Time used to live.

## Related Issues
Closes BHP1-1562

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open VMS (should auto-migrate) and sync
2. Create a new Surface + Contain worksheet
3. Select "Contain Status" output
4. Verify that "Fire Size at Report" appears in Suppression inputs
5. Verify that the following worksheet opens/runs:
[BHP1-1562.bp7.zip](https://github.com/user-attachments/files/28481313/BHP1-1562.bp7.zip)
