### PR TITLE
[BHP1-1593] Fix Missing Y Axis Limit Entry for Directional Parent Outputs

### DIFF
--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -472,13 +472,13 @@
  (fn [{ds                   :ds
        directional-children :vms/directional-children} [_ ws-uuid group-var-uuid attr value]]
    (when-let [graph-axis-limit-id (get-graph-axis-limit-eid ds ws-uuid group-var-uuid)]
-     (let [children-payload (map (fn [child]
-                                   (let [child-graph-axis-limit-id
-                                         (get-graph-axis-limit-eid ds ws-uuid (:bp/uuid child))]
-                                     (assoc {:db/id child-graph-axis-limit-id} attr value)))
-                                 directional-children)]
-       {:transact (cond-> [(assoc {:db/id graph-axis-limit-id} attr value)]
-                    (seq children-payload) (concat children-payload))}))))
+     (let [children-payload (for [child directional-children
+                                  :let  [child-graph-axis-limit-id (get-graph-axis-limit-eid ds ws-uuid (:bp/uuid child))]
+                                  :when child-graph-axis-limit-id]
+                              (assoc {:db/id child-graph-axis-limit-id} attr value))
+           final-payload    (cond-> [(assoc {:db/id graph-axis-limit-id} attr value)]
+                              (seq children-payload) (concat children-payload))]
+       {:transact final-payload}))))
 (rp/reg-event-fx
  :worksheet/update-all-axis-limits-from-results
  (fn [_ [_ ws-uuid]]


### PR DESCRIPTION
-------

## Purpose

- When a Directional parent is selected (i.e. Surface > Rate of Spread) and a multi valued input is entered in the worksheet, the resulting run is missing the entries for the y axis limits in the graph settings section. The event that updates the `y-axis-limit/min` and `y-axis-limit/max` were failing silently because there were some nil values for :db/id when processing children, which is expected for the case when we're only interested in the heading direction.

- This fix mirrors what's currently being done for the table setting filters `:worksheet/update-table-filter-attr`

## Related Issues
Closes BHP1-1593

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. open this worksheet: [BHP1-1593.zip](https://github.com/user-attachments/files/28722000/BHP1-1593.zip)
2. re-run this worksheet
3. navigate to review page and ensure under the Graph settings you see "Rate of Spread" entry in the "Y Graph Axis Limits" table

## Screenshots