### PR TITLE
BHP1-1541 Hide Graph legend for single range input

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/graphs.cljs
+++ b/projects/behave/src/cljs/behave/components/results/graphs.cljs
@@ -54,11 +54,13 @@
                           :discrete? @(subscribe [:wizard/discrete-group-variable? x-axis-group-variable-uuid])}
                  :y      {:name  @(subscribe [:wizard/gv-uuid->resolve-result-variable-name output-uuid])
                           :scale (when (and y-min y-max) [y-min y-max])}
-                 :z      {:name      @(subscribe [:wizard/gv-uuid->resolve-result-variable-name
-                                                  z-axis-group-variable-uuid])
-                          :discrete? true}
-                 :z2     {:name    @(subscribe [:wizard/gv-uuid->resolve-result-variable-name
-                                                z2-axis-group-variable-uuid])
-                          :columns 2}
+                 :z      (when z-axis-group-variable-uuid
+                           {:name      @(subscribe [:wizard/gv-uuid->resolve-result-variable-name
+                                                    z-axis-group-variable-uuid])
+                            :discrete? true})
+                 :z2     (when z2-axis-group-variable-uuid
+                           {:name    @(subscribe [:wizard/gv-uuid->resolve-result-variable-name
+                                                  z2-axis-group-variable-uuid])
+                            :columns 2})
                  :width  250
                  :height 250}))]])]))))


### PR DESCRIPTION
## Purpose
EOM

## Related Issues
Closes BHP1-1541

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
  1. Open a worksheet with one ranged (multi-valued) input
  2. Run the solver and navigate to the Graphs section
  3. Confirm the legend is no longer shown
  4. Add a second ranged input, re-run — confirm legend appears with both inputs listed