### PR TITLE
[BHP1-1611] Shade result tables per direction

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -41,19 +41,6 @@
        {}
        entries-by-row))))
 
-(defn- shade-cell-value? [table-setting-filters sig-digits output-gv-uuid value]
-  (let [[_ mmin mmax enabled?] (first (filter (fn [[gv-uuid]] (= gv-uuid output-gv-uuid))
-                                              table-setting-filters))
-        sig                    (get sig-digits output-gv-uuid)
-        rround                 (fn [n]
-                                 (if (and sig (some? n))
-                                   (js/parseFloat (gstring/format (str "%." sig "f") n))
-                                   n))
-        rounded                (rround (js/parseFloat value))
-        rounded-min            (rround mmin)
-        rounded-max            (rround mmax)]
-    (and enabled? mmin mmax (not (<= rounded-min rounded rounded-max)))))
-
 (defn- header-label [label units]
   (if (seq units)
     (gstring/format "%s (%s)" label units)
@@ -97,93 +84,6 @@
                   :col-gv-uuid    col-gv-uuid
                   :col-values     col-values
                   :output-gv-uuid output-gv-uuid}])))
-
-(defn- compute-shade-set-2d
-  [{:keys [ws-uuid row-gv-uuid row-values col-gv-uuid col-values output-entities table-setting-filters sig-digits submatrix-gv-uuid submatrix-value]}]
-  (reduce (fn [acc {output-gv-uuid :bp/uuid}]
-            (let [matrix-data (fetch-matrix-data-2d {:ws-uuid           ws-uuid
-                                                     :row-gv-uuid       row-gv-uuid
-                                                     :row-values        row-values
-                                                     :col-gv-uuid       col-gv-uuid
-                                                     :col-values        col-values
-                                                     :output-gv-uuid    output-gv-uuid
-                                                     :submatrix-gv-uuid submatrix-gv-uuid
-                                                     :submatrix-value   submatrix-value})]
-              (into acc
-                    (reduce-kv
-                     (fn [acc [row col] value]
-                       (cond-> acc
-                         (shade-cell-value? table-setting-filters sig-digits output-gv-uuid value)
-                         (conj [row col])))
-                     #{}
-                     matrix-data))))
-          #{}
-          output-entities))
-
-(defn- compute-shade-set
-  [{:keys [ws-uuid multi-valued-inputs all-output-gv-uuids all-output-entities graph-settings table-settings table-setting-filters sig-digits]}]
-  (case (count multi-valued-inputs)
-    1 (let [[_ _ multi-var-gv-uuid multi-var-values] (first multi-valued-inputs)
-            all-matrix-data-raw                      @(subscribe [:worksheet/matrix-table-data-single-multi-valued-input
-                                                                  ws-uuid
-                                                                  multi-var-gv-uuid
-                                                                  multi-var-values
-                                                                  (vec all-output-gv-uuids)])]
-        (reduce-kv (fn [acc [row col-uuid] v]
-                     (cond-> acc
-                       (shade-cell-value? table-setting-filters sig-digits col-uuid v)
-                       (conj row)))
-                   #{}
-                   all-matrix-data-raw))
-    2 (let [row-axis-gv-uuid             (or (:table-settings/row-group-variable-uuid table-settings)
-                                             (:graph-settings/z-axis-group-variable-uuid graph-settings))
-            col-axis-gv-uuid             (or (:table-settings/col-group-variable-uuid table-settings)
-                                             (:graph-settings/x-axis-group-variable-uuid graph-settings))
-            [_ _ row-gv-uuid row-values] (->> multi-valued-inputs
-                                              (filter (fn [[_ _ gv-uuid]] (= gv-uuid row-axis-gv-uuid)))
-                                              first)
-            [_ _ col-gv-uuid col-values] (->> multi-valued-inputs
-                                              (filter (fn [[_ _ gv-uuid]] (= gv-uuid col-axis-gv-uuid)))
-                                              first)]
-        (compute-shade-set-2d {:ws-uuid               ws-uuid
-                               :row-gv-uuid           row-gv-uuid
-                               :row-values            row-values
-                               :col-gv-uuid           col-gv-uuid
-                               :col-values            col-values
-                               :output-entities       all-output-entities
-                               :table-setting-filters table-setting-filters
-                               :sig-digits            sig-digits}))
-    3 (let [z2-axis-uuid                 (or (:table-settings/submatrix-group-variable-uuid table-settings)
-                                             (:graph-settings/z2-axis-group-variable-uuid graph-settings))
-            [_ _ z2-gv-uuid z2-values]   (->> multi-valued-inputs
-                                              (filter (fn [[_ _ gv-uuid]] (= gv-uuid z2-axis-uuid)))
-                                              first)
-            rest-inputs                  (filter (fn [[_ _ gv-uuid]] (not= gv-uuid z2-axis-uuid)) multi-valued-inputs)
-            row-axis-gv-uuid             (or (:table-settings/row-group-variable-uuid table-settings)
-                                             (:graph-settings/z-axis-group-variable-uuid graph-settings))
-            col-axis-gv-uuid             (or (:table-settings/col-group-variable-uuid table-settings)
-                                             (:graph-settings/x-axis-group-variable-uuid graph-settings))
-            [_ _ row-gv-uuid row-values] (->> rest-inputs
-                                              (filter (fn [[_ _ gv-uuid]] (= gv-uuid row-axis-gv-uuid)))
-                                              first)
-            [_ _ col-gv-uuid col-values] (->> rest-inputs
-                                              (filter (fn [[_ _ gv-uuid]] (= gv-uuid col-axis-gv-uuid)))
-                                              first)]
-        (reduce (fn [acc value]
-                  (assoc acc value
-                         (compute-shade-set-2d {:ws-uuid               ws-uuid
-                                                :row-gv-uuid           row-gv-uuid
-                                                :row-values            row-values
-                                                :col-gv-uuid           col-gv-uuid
-                                                :col-values            col-values
-                                                :output-entities       all-output-entities
-                                                :table-setting-filters table-setting-filters
-                                                :sig-digits            sig-digits
-                                                :submatrix-gv-uuid     z2-gv-uuid
-                                                :submatrix-value       value})))
-                {}
-                z2-values))
-    nil))
 
 (defn- build-matrix-data
   [matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn shade-set any-filters-enabled?]
@@ -583,17 +483,11 @@
         discrete-outputs-with-colors    (find-discrete-outputs-with-colors all-output-entities)
         color-output-state              @(subscribe [:wizard/selected-output-cell-coloring])
         cell-color-gv-uuid              (when-not (= :none color-output-state) color-output-state)
-        graph-settings                  @(subscribe [:worksheet/graph-settings ws-uuid])
-        table-settings                  @(subscribe [:worksheet/table-settings ws-uuid])
-        sig-digits                      @(subscribe [:worksheet/result-table-significant-digits all-output-gv-uuids])
-        shade-set                       (compute-shade-set {:ws-uuid               ws-uuid
-                                                            :multi-valued-inputs   multi-valued-inputs
-                                                            :all-output-gv-uuids   all-output-gv-uuids
-                                                            :all-output-entities   all-output-entities
-                                                            :graph-settings        graph-settings
-                                                            :table-settings        table-settings
-                                                            :table-setting-filters table-setting-filters
-                                                            :sig-digits            sig-digits})
+        ;; Non-directional outputs rely on the Heading direction for shading.
+        heading-direction               (some (fn [d] (when (= "heading" (str/lower-case (name d))) d)) directions)
+        heading-gv-uuids                (when heading-direction
+                                          (filter #(deref (subscribe [:vms/group-variable-is-directional? % heading-direction]))
+                                                  directional-gv-uuids))
         any-filters-enabled?            (boolean (some (fn [[_ _ _ enabled?]] enabled?) table-setting-filters))]
     (when (and (seq discrete-outputs-with-colors) (nil? color-output-state))
       (dispatch-sync [:wizard/set-discrete-color-output (:bp/uuid (first discrete-outputs-with-colors))]))
@@ -622,12 +516,15 @@
                :units-lookup         units-lookup
                :formatters           formatters
                :cell-color-gv-uuid   cell-color-gv-uuid
-               :shade-set            shade-set
+               :shade-set            @(subscribe [:worksheet/shade-set ws-uuid output-gv-uuids])
                :any-filters-enabled? any-filters-enabled?}])))
        (when (seq non-directional-output-gv-uuids)
          (let [group-variables (map (fn [gv-uuid] @(subscribe [:wizard/group-variable gv-uuid])) non-directional-output-gv-uuids)
                output-entities (map (fn [gv] (merge gv {:units (get units-lookup (:bp/uuid gv))})) group-variables)
-               formatters      @(subscribe [:worksheet/result-table-formatters non-directional-output-gv-uuids])]
+               formatters      @(subscribe [:worksheet/result-table-formatters non-directional-output-gv-uuids])
+               ;; Shade non-directional results by their own outputs plus the
+               ;; Heading direction's, so rows align with the Heading table.
+               shade-scope     (concat non-directional-output-gv-uuids heading-gv-uuids)]
            [construct-result-matrices
             {:ws-uuid              ws-uuid
              :title                @(<t (bp "results"))
@@ -638,5 +535,5 @@
              :units-lookup         units-lookup
              :formatters           formatters
              :cell-color-gv-uuid   cell-color-gv-uuid
-             :shade-set            shade-set
+             :shade-set            @(subscribe [:worksheet/shade-set ws-uuid shade-scope])
              :any-filters-enabled? any-filters-enabled?}]))])))

--- a/projects/behave/src/cljs/behave/components/results/table.cljs
+++ b/projects/behave/src/cljs/behave/components/results/table.cljs
@@ -1,5 +1,6 @@
 (ns behave.components.results.table
   (:require [behave.components.core  :as c]
+            [behave.results.shading  :as shading]
             [behave.translate        :refer [<t bp]]
             [behave.units-conversion :refer [to-map-units]]
             [behave.wizard.subs      :refer [all-conditionals-pass?]]
@@ -54,19 +55,37 @@
                :icon-position "left"
                :on-click      download!}]))
 
+(defn shades-row?
+  "Whether `col-uuid` may strike its run's row in the flat results table. A row
+  is direction-aware via the Heading rule: non-directional and Heading columns
+  count; Backing/Flanking columns do not, so the flat table aligns with the
+  Heading matrix rather than shading across all directions."
+  [directional-uuids heading-uuids col-uuid]
+  (or (not (contains? directional-uuids col-uuid))
+      (contains? heading-uuids col-uuid)))
+
 (defn- build-result-table-data
   [{:keys [ws-uuid headers title cell-data]}]
   (let [headers                   (or headers @(subscribe [:worksheet/result-table-headers-sorted ws-uuid]))
         title                     (or title "Results Table")
         cell-data                 (or cell-data @(subscribe [:worksheet/result-table-cell-data ws-uuid]))
-        headers-set               (set (map first headers))
-        table-setting-filters     (subscribe [:worksheet/table-settings-filters ws-uuid])
+        header-uuids              (map first headers)
+        headers-set               (set header-uuids)
+        table-setting-filters     @(subscribe [:worksheet/table-settings-filters ws-uuid])
+        filters-by-uuid           (shading/filters-by-uuid table-setting-filters)
+        sig-digits                @(subscribe [:worksheet/result-table-significant-digits header-uuids])
+        directional-uuids         (set @(subscribe [:vms/directional-group-variable-uuids]))
+        directions                @(subscribe [:worksheet/output-directions ws-uuid])
+        heading-direction         (some (fn [d] (when (= "heading" (str/lower-case (name d))) d)) directions)
+        heading-uuids             (set (when heading-direction
+                                         (filter #(deref (subscribe [:vms/group-variable-is-directional? % heading-direction]))
+                                                 (filter directional-uuids header-uuids))))
         map-units-settings-entity @(subscribe [:worksheet/map-units-settings-entity ws-uuid])
         map-units-enabled?        (:map-units-settings/enabled? map-units-settings-entity)
         map-units                 (:map-units-settings/units map-units-settings-entity)
         map-rep-frac              (:map-units-settings/map-rep-fraction map-units-settings-entity)
         map-units-variables       @(subscribe [:worksheet/result-table-units ws-uuid])
-        formatters                @(subscribe [:worksheet/result-table-formatters (map first headers)])]
+        formatters                @(subscribe [:worksheet/result-table-formatters header-uuids])]
     {:title   title
      :headers (reduce (fn resolve-uuid [acc [gv-uuid _repeat-id units]]
                         (let [header-name @(subscribe [:wizard/gv-uuid->resolve-result-variable-name gv-uuid])]
@@ -92,14 +111,11 @@
                                        (sort-by key))]
                 (map (fn [[_ data]]
                        (reduce (fn [acc [_row-id col-uuid repeat-id value]]
-                                 (let [[_ filter-min filter-max enabled?] (first (filter
-                                                                                  (fn [[gv-uuid]]
-                                                                                    (= gv-uuid col-uuid))
-                                                                                  @table-setting-filters))
-                                       fmt-fn                             (get formatters col-uuid identity)
-                                       uuid+repeat-id-key                 (keyword (str col-uuid "-" repeat-id))]
+                                 (let [fmt-fn             (get formatters col-uuid identity)
+                                       uuid+repeat-id-key (keyword (str col-uuid "-" repeat-id))]
                                    (cond-> acc
-                                     (and filter-min filter-max (not (<= filter-min value filter-max)) enabled?)
+                                     (and (shades-row? directional-uuids heading-uuids col-uuid)
+                                          (shading/out-of-range? filters-by-uuid sig-digits col-uuid value))
                                      (assoc :shaded? true)
 
                                      :always

--- a/projects/behave/src/cljs/behave/results/shading.cljs
+++ b/projects/behave/src/cljs/behave/results/shading.cljs
@@ -1,0 +1,50 @@
+(ns behave.results.shading
+  "Pure helpers for deciding which result cells fall outside an enabled
+  table-filter range (the \"shaded\" cells).
+
+  No subscriptions or reactive state lives here: callers supply already-fetched
+  matrix data so the range math can be unit-tested in isolation and shared by
+  every view that shades results (matrices, flat table, CSV export)."
+  (:require [goog.string :as gstring]))
+
+(defn- round-to
+  "Round `n` to `sig` decimal places, matching the result-table formatter.
+  Returns `n` unchanged when `sig` or `n` is nil."
+  [sig n]
+  (if (and sig (some? n))
+    (js/parseFloat (gstring/format (str "%." sig "f") n))
+    n))
+
+(defn out-of-range?
+  "True when `value` for `output-gv-uuid` falls outside its enabled filter range.
+
+  - `filters-by-uuid` : map of output gv-uuid -> `[gv-uuid min max enabled?]`
+  - `sig-digits`      : map of output gv-uuid -> significant decimal places
+  - `value`           : the cell value (number or numeric string)"
+  [filters-by-uuid sig-digits output-gv-uuid value]
+  (let [[_ mmin mmax enabled?] (get filters-by-uuid output-gv-uuid)
+        rnd                    (partial round-to (get sig-digits output-gv-uuid))
+        rounded                (rnd (js/parseFloat value))]
+    (boolean (and enabled? mmin mmax
+                  (not (<= (rnd mmin) rounded (rnd mmax)))))))
+
+(defn shade-set
+  "Return the set of positions whose value is out of range.
+
+  `cells` is a seq of `[position output-gv-uuid value]` tuples. `position` is
+  opaque to this fn — a row key when there is one multi-valued input, or a
+  `[row col]` pair when there are two — so the same reducer serves both layouts."
+  [filters-by-uuid sig-digits cells]
+  (reduce (fn [acc [position output-gv-uuid value]]
+            (cond-> acc
+              (out-of-range? filters-by-uuid sig-digits output-gv-uuid value)
+              (conj position)))
+          #{}
+          cells))
+
+(defn filters-by-uuid
+  "Index a `:worksheet/table-settings-filters` seq (`[gv-uuid min max enabled?]`
+  tuples) by group-variable uuid for O(1) lookup in [[out-of-range?]]."
+  [table-setting-filters]
+  (into {} (map (fn [[gv-uuid :as filter-tuple]] [gv-uuid filter-tuple]))
+        table-setting-filters))

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -1,5 +1,6 @@
 (ns behave.worksheet.subs
   (:require [austinbirch.reactive-entity :as re]
+            [behave.results.shading      :as shading]
             [behave.schema.core          :refer [rules]]
             [behave.store                :as s]
             [behave.translate            :refer [<t]]
@@ -691,6 +692,92 @@
             (directional-parent-entity group-var-uuid))))
     table-settings-filters)))
 
+;;==============================================================================
+;; Shade set
+;;
+;; Which result positions fall outside an enabled table-filter range. This sub
+;; centralizes the matrix-data gathering that used to be spread across the
+;; `result-matrices` view helpers and hands the range math to the pure
+;; `behave.results.shading` core. Parameterized by `output-gv-uuids` (the
+;; "scope") so a single direction's outputs can be shaded independently.
+;;==============================================================================
+
+(defn- axis-uuids
+  "Resolve the row/col (and optional submatrix) axis group-variable uuids from
+  table-settings, falling back to graph-settings — mirrors the matrix view."
+  [table-settings graph-settings]
+  {:row       (or (:table-settings/row-group-variable-uuid table-settings)
+                  (:graph-settings/z-axis-group-variable-uuid graph-settings))
+   :col       (or (:table-settings/col-group-variable-uuid table-settings)
+                  (:graph-settings/x-axis-group-variable-uuid graph-settings))
+   :submatrix (or (:table-settings/submatrix-group-variable-uuid table-settings)
+                  (:graph-settings/z2-axis-group-variable-uuid graph-settings))})
+
+(defn- input-by-uuid [multi-valued-inputs gv-uuid]
+  (->> multi-valued-inputs
+       (filter (fn [[_ _ gv]] (= gv gv-uuid)))
+       first))
+
+(defn- cells-2d
+  "Seq of `[[row col] output-gv-uuid value]` tuples across `output-gv-uuids`,
+  optionally constrained to a single `submatrix-value` (the 3-input case)."
+  [{:keys [ws-uuid output-gv-uuids row-gv-uuid row-values col-gv-uuid col-values
+           submatrix-gv-uuid submatrix-value]}]
+  (mapcat
+   (fn [output-gv-uuid]
+     (let [base {:ws-uuid    ws-uuid    :row-gv-uuid    row-gv-uuid
+                 :row-values row-values :col-gv-uuid    col-gv-uuid
+                 :col-values col-values :output-gv-uuid output-gv-uuid}
+           data (if submatrix-value
+                  @(rf/subscribe [:print/matrix-table-three-multi-valued-inputs
+                                  (assoc base :submatrix-gv-uuid submatrix-gv-uuid
+                                         :submatrix-value submatrix-value)])
+                  @(rf/subscribe [:print/matrix-table-two-multi-valued-inputs base]))]
+       (map (fn [[pos v]] [pos output-gv-uuid v]) data)))
+   output-gv-uuids))
+
+(rf/reg-sub
+ :worksheet/shade-set
+ (fn [[_ ws-uuid _output-gv-uuids]]
+   [(rf/subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
+    (rf/subscribe [:worksheet/table-settings ws-uuid])
+    (rf/subscribe [:worksheet/graph-settings ws-uuid])
+    (rf/subscribe [:worksheet/table-settings-filters ws-uuid])])
+ (fn [[multi-valued-inputs table-settings graph-settings table-setting-filters]
+      [_ ws-uuid output-gv-uuids]]
+   (let [filters    (shading/filters-by-uuid table-setting-filters)
+         sig-digits @(rf/subscribe [:worksheet/result-table-significant-digits output-gv-uuids])
+         shade      (partial shading/shade-set filters sig-digits)]
+     (case (count multi-valued-inputs)
+       1 (let [[_ _ mvi-gv-uuid mvi-values] (first multi-valued-inputs)
+               data                         @(rf/subscribe [:worksheet/matrix-table-data-single-multi-valued-input
+                                                            ws-uuid mvi-gv-uuid mvi-values (vec output-gv-uuids)])]
+           (shade (map (fn [[[row col-uuid] v]] [row col-uuid v]) data)))
+
+       2 (let [{row-axis :row col-axis :col} (axis-uuids table-settings graph-settings)
+               [_ _ row-gv-uuid row-values]  (input-by-uuid multi-valued-inputs row-axis)
+               [_ _ col-gv-uuid col-values]  (input-by-uuid multi-valued-inputs col-axis)]
+           (shade (cells-2d {:ws-uuid     ws-uuid     :output-gv-uuids output-gv-uuids
+                             :row-gv-uuid row-gv-uuid :row-values      row-values
+                             :col-gv-uuid col-gv-uuid :col-values      col-values})))
+
+       3 (let [{row-axis :row col-axis :col sub-axis :submatrix} (axis-uuids table-settings graph-settings)
+               [_ _ sub-gv-uuid sub-values]                      (input-by-uuid multi-valued-inputs sub-axis)
+               rest-inputs                                       (remove (fn [[_ _ gv]] (= gv sub-axis)) multi-valued-inputs)
+               [_ _ row-gv-uuid row-values]                      (input-by-uuid rest-inputs row-axis)
+               [_ _ col-gv-uuid col-values]                      (input-by-uuid rest-inputs col-axis)]
+           ;; map of submatrix-value -> shade set, matching the 3-input view
+           (into {} (map (fn [sub-value]
+                           [sub-value
+                            (shade (cells-2d {:ws-uuid           ws-uuid     :output-gv-uuids output-gv-uuids
+                                              :row-gv-uuid       row-gv-uuid :row-values      row-values
+                                              :col-gv-uuid       col-gv-uuid :col-values      col-values
+                                              :submatrix-gv-uuid sub-gv-uuid
+                                              :submatrix-value   sub-value}))])
+                         sub-values)))
+
+       #{}))))
+
 ;; Results Table formatters
 
 (defn ^:private create-formatter [variable multi-discrete? is-output?]
@@ -801,25 +888,25 @@
 (rp/reg-sub
  :worksheet/result-table-cell-data
  (fn [_ [_ ws-uuid]]
-   {:type     :query
-    :query    '[:find ?row ?col-uuid ?repeat-id ?value
-                :in $ ?ws-uuid
-                :where
-                [?w :worksheet/uuid ?ws-uuid]
-                [?w :worksheet/result-table ?rt]
-                [?rt :result-table/rows ?r]
+   {:type      :query
+    :query     '[:find ?row ?col-uuid ?repeat-id ?value
+                 :in $ ?ws-uuid
+                 :where
+                 [?w :worksheet/uuid ?ws-uuid]
+                 [?w :worksheet/result-table ?rt]
+                 [?rt :result-table/rows ?r]
 
              ;;get row
-                [?r :result-row/id ?row]
+                 [?r :result-row/id ?row]
 
              ;;get-header
-                [?r :result-row/cells ?c]
-                [?c :result-cell/header ?h]
-                [?h :result-header/group-variable-uuid ?col-uuid]
-                [?h :result-header/repeat-id ?repeat-id]
+                 [?r :result-row/cells ?c]
+                 [?c :result-cell/header ?h]
+                 [?h :result-header/group-variable-uuid ?col-uuid]
+                 [?h :result-header/repeat-id ?repeat-id]
 
              ;;get value
-                [?c :result-cell/value ?value]]
+                 [?c :result-cell/value ?value]]
     :variables
     [ws-uuid]}))
 

--- a/projects/behave/test/cljs/behave/results_table_test.cljs
+++ b/projects/behave/test/cljs/behave/results_table_test.cljs
@@ -1,0 +1,23 @@
+(ns behave.results-table-test
+  (:require [behave.components.results.table :as sut]
+            [cljs.test                       :refer [deftest is testing]]))
+
+;; A directional output (spread rate) split into Heading/Backing/Flanking
+;; children, plus a non-directional output (reaction intensity).
+(def directional-uuids #{"heading-sr" "backing-sr" "flanking-sr"})
+(def heading-uuids     #{"heading-sr"})
+
+(deftest shades-row?-heading-rule-test
+  (testing "non-directional columns always strike their run's row"
+    (is (true? (sut/shades-row? directional-uuids heading-uuids "rxn-intensity"))))
+
+  (testing "the Heading directional column strikes the row"
+    (is (true? (sut/shades-row? directional-uuids heading-uuids "heading-sr"))))
+
+  (testing "Backing/Flanking columns never strike the row"
+    (is (false? (sut/shades-row? directional-uuids heading-uuids "backing-sr")))
+    (is (false? (sut/shades-row? directional-uuids heading-uuids "flanking-sr"))))
+
+  (testing "with no Heading children, only non-directional columns strike"
+    (is (true?  (sut/shades-row? directional-uuids #{} "rxn-intensity")))
+    (is (false? (sut/shades-row? directional-uuids #{} "heading-sr")))))

--- a/projects/behave/test/cljs/behave/shading_test.cljs
+++ b/projects/behave/test/cljs/behave/shading_test.cljs
@@ -1,0 +1,99 @@
+(ns behave.shading-test
+  (:require [behave.results.shading :as shading]
+            [cljs.test              :refer [deftest is testing]]))
+
+;; A spread-rate output with an enabled filter range of [5 10].
+(def filters
+  (shading/filters-by-uuid
+   [["spread-rate"   5   10  true]
+    ["flame-length"  2   4   false]]))  ;; present but disabled
+
+(deftest out-of-range?-test
+  (testing "value inside an enabled range is in-range"
+    (is (false? (shading/out-of-range? filters {} "spread-rate" 7))))
+
+  (testing "value outside an enabled range is out-of-range"
+    (is (true? (shading/out-of-range? filters {} "spread-rate" 12)))
+    (is (true? (shading/out-of-range? filters {} "spread-rate" 1))))
+
+  (testing "boundary values are inclusive"
+    (is (false? (shading/out-of-range? filters {} "spread-rate" 5)))
+    (is (false? (shading/out-of-range? filters {} "spread-rate" 10))))
+
+  (testing "disabled filter never shades"
+    (is (false? (shading/out-of-range? filters {} "flame-length" 99))))
+
+  (testing "output with no filter never shades"
+    (is (false? (shading/out-of-range? filters {} "reaction-intensity" 99))))
+
+  (testing "rounding to significant digits honors the displayed value"
+    ;; 10.4 displays as "10" at 0 sig digits, so it should read as in-range.
+    (is (false? (shading/out-of-range? filters {"spread-rate" 0} "spread-rate" 10.4)))
+    ;; ...but as out-of-range when shown to one decimal place.
+    (is (true? (shading/out-of-range? filters {"spread-rate" 1} "spread-rate" 10.4))))
+
+  (testing "numeric strings are accepted (matrix data arrives as strings)"
+    (is (true? (shading/out-of-range? filters {} "spread-rate" "12")))))
+
+(deftest shade-set-1d-test
+  (testing "collects row positions whose output value is out of range"
+    (let [cells [["row-a" "spread-rate" 7]    ;; in range
+                 ["row-b" "spread-rate" 12]   ;; out
+                 ["row-c" "spread-rate" 3]]]  ;; out
+      (is (= #{"row-b" "row-c"}
+             (shading/shade-set filters {} cells))))))
+
+(deftest shade-set-2d-test
+  (testing "collects [row col] positions and unions across outputs"
+    (let [cells [[[0 0] "spread-rate"  7]    ;; in
+                 [[0 1] "spread-rate"  20]   ;; out
+                 [[1 0] "flame-length" 99]]] ;; disabled filter -> in
+      (is (= #{[0 1]}
+             (shading/shade-set filters {} cells))))))
+
+(deftest filters-by-uuid-test
+  (testing "indexes a table-settings-filters seq by group-variable uuid"
+    (is (= {"a" ["a" 1 2 true] "b" ["b" 3 4 false]}
+           (shading/filters-by-uuid [["a" 1 2 true] ["b" 3 4 false]])))))
+
+;; A directional output whose Heading/Backing children share the same [5 10]
+;; filter (filters fan out from the parent to its children identically).
+(def directional-filters
+  (shading/filters-by-uuid
+   [["heading-sr" 5 10 true]
+    ["backing-sr" 5 10 true]]))
+
+(deftest shade-set-respects-scope-test
+  (testing "each direction's shade-set reflects only that direction's cells"
+    (let [heading-cells [["r1" "heading-sr" 7]     ;; in
+                         ["r2" "heading-sr" 99]]   ;; out
+          backing-cells [["r1" "backing-sr" 99]    ;; out
+                         ["r2" "backing-sr" 7]]]   ;; in
+      ;; Heading scope shades r2 only; Backing's out-of-range r1 does not leak in.
+      (is (= #{"r2"} (shading/shade-set directional-filters {} heading-cells)))
+      ;; Backing scope shades r1 only; independent of Heading.
+      (is (= #{"r1"} (shading/shade-set directional-filters {} backing-cells)))
+      ;; The old "across all runs" behavior (one combined set) shaded both — this
+      ;; is exactly what direction-scoping replaces.
+      (is (= #{"r1" "r2"}
+             (shading/shade-set directional-filters {} (concat heading-cells backing-cells)))))))
+
+(deftest shade-set-non-directional-relies-on-heading-test
+  ;; The non-directional table scopes its cells to its own outputs + the Heading
+  ;; children (done in the view/sub). These cases show why that scope is correct:
+  ;; Heading drives shading and Backing — if it were passed — would not.
+  (testing "non-directional scope = own outputs + Heading children"
+    (let [f       (shading/filters-by-uuid
+                   [["rxn-intensity" 5 10 true]
+                    ["heading-sr"    5 10 true]
+                    ["backing-sr"    5 10 true]])
+          non-dir [["r1" "rxn-intensity" 7]]    ;; in range
+          heading [["r1" "heading-sr"    99]]   ;; out of range
+          backing [["r1" "backing-sr"    99]]]  ;; out of range
+      ;; Non-directional + Heading: the Heading out-of-range value shades the row.
+      (is (= #{"r1"} (shading/shade-set f {} (concat non-dir heading))))
+      ;; Non-directional outputs alone are all in range — nothing shaded.
+      (is (= #{} (shading/shade-set f {} non-dir)))
+      ;; Backing WOULD shade if scoped in — which is exactly why the view excludes
+      ;; it from the non-directional table.
+      (is (= #{"r1"} (shading/shade-set f {} backing))))))

--- a/projects/behave/test/cljs/behave/test_runner.cljs
+++ b/projects/behave/test/cljs/behave/test_runner.cljs
@@ -1,18 +1,20 @@
 (ns behave.test-runner
-  (:require [behave.events]
-            [behave.help.subs]
-            [behave.subs]
-            [behave.vms.store :refer [load-vms!]]
-            [behave.contain-test]
+  (:require [behave.contain-test]
             [behave.crown-test]
             [behave.diagram-test]
+            [behave.events]
+            [behave.help.subs]
             [behave.mortality-test]
+            [behave.results-table-test]
+            [behave.shading-test]
             [behave.solver-test]
+            [behave.subs]
             [behave.surface-test]
             [behave.test-solver-generators]
             [behave.test-solver-queries]
             [behave.tests-used-in-fixtures]
             [behave.utils-test]
+            [behave.vms.store :refer [load-vms!]]
             [behave.vms.subs]
             [behave.wizard.events]
             [behave.wizard.subs]
@@ -37,6 +39,8 @@
              'behave.crown-test
              'behave.contain-test
              'behave.mortality-test
+             'behave.results-table-test
+             'behave.shading-test
              'behave.diagram-test
              'behave.surface-test
              'behave.solver-test
@@ -45,8 +49,7 @@
              'behave.test-solver-queries
              'behave.utils-test
              'behave.worksheet-events-test
-             'behave.worksheet-subs-test
-             ))
+             'behave.worksheet-subs-test))
 
 (defn ^:after-load init []
   (let [window-keys    (js->clj (.keys js/Object js/window))

--- a/projects/behave/test/cljs/behave/test_runner.cljs
+++ b/projects/behave/test/cljs/behave/test_runner.cljs
@@ -63,7 +63,9 @@
 
       (not vms-loaded?)
       (do
-        (load-vms!)
+        ;; `version` is only a cache-buster query param; the test server serves
+        ;; layout.msgpack statically and ignores it.
+        (load-vms! "test")
         (js/setTimeout #(init) 1000))
 
       :else

--- a/projects/behave/test/cljs/behave/worksheet_subs_test.cljs
+++ b/projects/behave/test/cljs/behave/worksheet_subs_test.cljs
@@ -1,8 +1,8 @@
 (ns behave.worksheet-subs-test
   (:require
+   [behave.fixtures :as fx]
    [cljs.test :refer [use-fixtures deftest is join-fixtures] :include-macros true]
-   [re-frame.core :as rf]
-   [behave.fixtures :as fx]))
+   [re-frame.core :as rf]))
 
 (use-fixtures :each
   {:before (join-fixtures [fx/setup-empty-db fx/with-new-worksheet fx/with-dummy-results-table])
@@ -45,3 +45,11 @@
   (is (= @(rf/subscribe [:worksheet/output-min+max-values fx/test-ws-uuid])
          {"output1" [10 30]
           "output2" [100 300]})))
+
+(deftest shade-set-no-multi-valued-inputs-test
+  ;; The dummy results table has no multi-valued inputs, so the sub takes its
+  ;; 0-input branch and produces an empty set (nothing to shade). This exercises
+  ;; the sub's signal graph + registration end-to-end. Cell-level shading logic
+  ;; is covered exhaustively in behave.shading-test.
+  (is (= #{}
+         @(rf/subscribe [:worksheet/shade-set fx/test-ws-uuid ["output1" "output2"]]))))

--- a/projects/behave/test/cljs/behave/worksheet_subs_test.cljs
+++ b/projects/behave/test/cljs/behave/worksheet_subs_test.cljs
@@ -9,15 +9,15 @@
    :after  (join-fixtures [fx/teardown-db])})
 
 (deftest sub-worksheet-test
-  (let [uuid           "test-ws-uuid"
+  (let [ws-uuid        "test-ws-uuid"
         worksheet-name "test"
-        sub-to-test    [:worksheet uuid]
+        sub-to-test    [:worksheet ws-uuid]
         *worksheet     (rf/subscribe sub-to-test)]
     (rf/dispatch-sync [:transact [{:db/id          -1
-                                   :worksheet/uuid uuid
+                                   :worksheet/uuid ws-uuid
                                    :worksheet/name worksheet-name}]])
 
-    (is (= (:worksheet/uuid @*worksheet) uuid))
+    (is (= (:worksheet/uuid @*worksheet) ws-uuid))
 
     (is (= (:worksheet/name @*worksheet) worksheet-name))))
 


### PR DESCRIPTION
## Purpose
- Shade each direction's outputs independently — a filter range no longer strikes Backing/Flanking cells against the Heading scale.
- Extract the range math into a pure `behave.results.shading` core and a single `:worksheet/shade-set` sub, replacing the logic duplicated across the matrix / results tables.
- Parameterize shading by output scope to shade one direction at a time.
- Round comparisons to the result-table formatter's significant digits, to make values and shading filters agree.

## Related Issues
Closes BHP1-1611

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open a worksheet with a directional output (e.g. Surface rate of spread) and multiple directions enabled (Heading, Backing, Flanking).
2. Enable a table shading filter with that fits Heading Rate of Spread' values.
3. Confirm only out-of-range cells _within each direction_ are shaded — Backing and Flanking shade against their own values, not the Heading range.
4. Switch between the matrix views (1, 2, and 3 multi-valued inputs) and the flat results table; shading stays consistent and the flat table matches the Heading matrix.
5. Toggle the filter off and confirm shading clears everywhere.
6. Run CLJS tests: `shading_test.cljs`, `results_table_test.cljs~, ~worksheet_subs_test.cljs~.