### PR TITLE
[BHP1-1532] Fix graph axes limits

### DIFF
--- a/projects/behave/src/cljs/behave/components/vega/result_chart.cljs
+++ b/projects/behave/src/cljs/behave/components/vega/result_chart.cljs
@@ -1,6 +1,6 @@
 (ns behave.components.vega.result-chart
-  (:require [cljsjs.vega-embed]
-            [behave.components.vega.core :refer [vega-box]]))
+  (:require [behave.components.vega.core :refer [vega-box]]
+            [cljsjs.vega-embed]))
 
 (defn build-line-chart
   "Given a map of with the following entries:
@@ -16,33 +16,34 @@
         (defaults to 1)."
   [{:keys [data x y z z2 width height]}]
   (when (and x y)
-    (let [line-chart {:mark (cond-> {}
-                              (:discrete? x)
-                              (assoc :type "bar")
+    (let [line-chart {:mark     (cond-> {}
+                                  (:discrete? x)
+                                  (assoc :type "bar")
 
-                              (not (:discrete? x))
-                              (merge {:type        "line"
-                                      :interpolate "monotone"})
+                                  (not (:discrete? x))
+                                  (merge {:type        "line"
+                                          :interpolate "monotone"
+                                          :strokeWidth 3})
 
-                              (:scale y)
-                              (assoc :clip true))
-                      :encoding (cond-> {:x     (cond-> {:field (:name x)
-                                                         :type  (if (:discrete? x)
-                                                                  "nominal"
-                                                                  "quantitative")}
-                                                  (and (not (:discrete? x)) (:scale x))
-                                                  (assoc :scale {:domain (:scale x)}))
-                                         :y     (cond-> {:field     (:name y)
-                                                         :type      "quantitative"}
-                                                  (:scale y)
-                                                  (assoc :scale {:domain (:scale y)}))}
+                                  (:scale y)
+                                  (assoc :clip true))
+                      :encoding (cond-> {:x (cond-> {:field (:name x)
+                                                     :type  (if (:discrete? x)
+                                                              "nominal"
+                                                              "quantitative")}
+                                              (and (not (:discrete? x)) (:scale x))
+                                              (assoc :scale {:domain (:scale x)}))
+                                         :y (cond-> {:field (:name y)
+                                                     :type  "quantitative"}
+                                              (:scale y)
+                                              (assoc :scale {:domain (:scale y)}))}
                                   z
-                                  (merge {:shape {:field  (:name z)
-                                                  :type   "nominal"
-                                                  :legend nil}
-                                          :color {:field  (:name z)
-                                                  :type   "nominal"
-                                                  :legend nil}
+                                  (merge {:shape   {:field  (:name z)
+                                                    :type   "nominal"
+                                                    :legend nil}
+                                          :color   {:field  (:name z)
+                                                    :type   "nominal"
+                                                    :legend nil}
                                           :xOffset {:field (:name z)}})
                                   z2
                                   (assoc :facet {:field   (:name z2)
@@ -52,24 +53,24 @@
                       :resolve  {:axis {:x "independent" :y "independent"}}
                       :width    width
                       :height   height}
-          z-name   (:name z)
-          z-legend {:mark     {:type "point"}
-                    :title    z-name
-                    :encoding {:shape {:field     z-name
-                                       :type      "nominal"
-                                       :aggregate "min"
-                                       :legend    nil}
-                               :color {:field     z-name
-                                       :type      "nominal"
-                                       :aggregate "min"
-                                       :legend    nil}
-                               :fill  {:field     z-name
-                                       :type      "nominal"
-                                       :aggregate "min"
-                                       :legend    nil}
-                               :y     {:field z-name
-                                       :type  "nominal"
-                                       :title nil}}}]
+          z-name     (:name z)
+          z-legend   {:mark     {:type "point"}
+                      :title    z-name
+                      :encoding {:shape {:field     z-name
+                                         :type      "nominal"
+                                         :aggregate "min"
+                                         :legend    nil}
+                                 :color {:field     z-name
+                                         :type      "nominal"
+                                         :aggregate "min"
+                                         :legend    nil}
+                                 :fill  {:field     z-name
+                                         :type      "nominal"
+                                         :aggregate "min"
+                                         :legend    nil}
+                                 :y     {:field z-name
+                                         :type  "nominal"
+                                         :title nil}}}]
       (cond-> {:$schema     "https://vega.github.io/schema/vega-lite/v2.json"
                :description "test"
                :data        {:values data}}

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -508,11 +508,9 @@
                   (let [[_min-to-use max-to-use] (if-let [direcitonal-parent-uuid (:bp/uuid (directional-parent-entity gv-uuid))]
                                                    (get output-min-max-values direcitonal-parent-uuid)
                                                    [min-val max-val])
-                        y-max-raw                (if (< max-val 1)
-                                                   (to-precision max-to-use 1)
-                                                   (math/round max-to-use))
-                        step                     (nice-step-size y-max-raw)
-                        y-max                    (+ y-max-raw step)]
+                        ;; FIX: BHP1-1532 - do not clip max values
+                        step                     (nice-step-size max-to-use)
+                        y-max                    (+ max-to-use step)]
                     (-> acc
                         (conj [:dispatch [:worksheet/update-y-axis-limit-attr
                                           ws-uuid


### PR DESCRIPTION
## Purpose
Fixes both line widths (thicker) and max Y values getting clipped

## Related Issues
Closes BHP1-1532

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open the following worksheet: [GraphAxes.bp7.zip](https://github.com/user-attachments/files/29521534/GraphAxes.bp7.zip)
2. Verify that the max Y values on the chart are no longer clipped

## Screenshots
<img width="343" height="340" alt="Screenshot 2026-06-30 at 1 02 15 PM" src="https://github.com/user-attachments/assets/c3f727c7-7a83-4d86-9579-a53e33ec8bfc" />
