### PR TITLE
Fix enabling filters for directional inputs when H/F/B isn't enabled

### DIFF
--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -626,18 +626,20 @@
                          [?f :table-filter/group-variable-uuid ?gv-uuid]]
                        ds ws-uuid gv-uuid)]
      (let [enabled?         (:table-filter/enabled? (d/entity ds eid))
-           children-payload (map (fn [child]
-                                   (let [table-filter-id (d/q '[:find ?f .
-                                                                :in $ ?uuid ?gv-uuid
-                                                                :where
-                                                                [?w :worksheet/uuid ?uuid]
-                                                                [?w :worksheet/table-settings ?t]
-                                                                [?t :table-settings/filters ?f]
-                                                                [?f :table-filter/group-variable-uuid ?gv-uuid]]
-                                                              ds ws-uuid (:bp/uuid child))]
-                                     {:db/id                 table-filter-id
-                                      :table-filter/enabled? (not enabled?)}))
-                                 directional-children)]
+           children-payload (->> directional-children
+                                 (map (fn [child]
+                                        (let [table-filter-id (d/q '[:find ?f .
+                                                                     :in $ ?uuid ?gv-uuid
+                                                                     :where
+                                                                     [?w :worksheet/uuid ?uuid]
+                                                                     [?w :worksheet/table-settings ?t]
+                                                                     [?t :table-settings/filters ?f]
+                                                                     [?f :table-filter/group-variable-uuid ?gv-uuid]]
+                                                                   ds ws-uuid (:bp/uuid child))]
+                                          (when table-filter-id
+                                            {:db/id                 table-filter-id
+                                             :table-filter/enabled? (not enabled?)}))))
+                                 (filter some?))]
        {:transact (cond-> [{:db/id                 eid
                             :table-filter/enabled? (not enabled?)}]
                     (seq children-payload) (concat children-payload))}))))


### PR DESCRIPTION
## Purpose
EOM

## Related Issues
N/A

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Open a new Guided workflow
2. Select Heading / Rate of Spread as outputs
3. Add inputs, with Wind Speed as `0,10,20,30`
4. Verify that the Rate of Spread table filter can be toggled on/off
5. Update the minimum, verify that filters do operate on results table
5. Save the worksheet, refresh (home)
6. Reopen the worksheet, verify that the table filter has persisted