### PR TITLE
[BHP1-1618] Only perform :sync/flush on Result Settings page

### DIFF
--- a/projects/behave/src/cljs/behave/events.cljs
+++ b/projects/behave/src/cljs/behave/events.cljs
@@ -102,8 +102,6 @@
      {:db                 (assoc db :router {:history new-history :curr-position new-position})
       :browser/scroll-top {}
       :help/scroll-top    {}
-      ;; Flush pending tx-data so edits survive a later reload.
-      :sync/flush         {}
       :history/push-state {:position new-position
                            :route    new-route}})))
 

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -423,6 +423,8 @@
                      :default-max-values @(subscribe [:worksheet/output-uuid->result-min-or-max-values ws-uuid :max])
                      :on-toggle-row      #(dispatch [:worksheet/toggle-enable-filter ws-uuid %])}]]))
 
+;; Wizard Results Settings Page
+
 (defn wizard-results-settings-page [{:keys [route-handler ws-uuid workflow]}]
   (dispatch-sync [:worksheet/update-furthest-visited-step ws-uuid route-handler nil])
   (when ws-uuid
@@ -430,9 +432,11 @@
   (let [modules              @(subscribe [:worksheet/modules ws-uuid])
         *show-notes?         (subscribe [:wizard/show-notes?])
         on-back              #(dispatch [:wizard/back])
-        on-next              #(dispatch [:navigate (path-for routes :ws/results
-                                                             {:ws-uuid  ws-uuid
-                                                              :workflow workflow})])
+        on-next              #(do
+                                (dispatch-sync [:sync/flush])
+                                (dispatch [:navigate (path-for routes :ws/results
+                                                               {:ws-uuid  ws-uuid
+                                                                :workflow workflow})]))
         show-tool-selector?  @(subscribe [:tool/show-tool-selector?])
         selected-tool-uuid   @(subscribe [:tool/selected-tool-uuid])
         show-graph-settings? @(subscribe [:wizard/show-graph-settings? ws-uuid])


### PR DESCRIPTION
-------

## Purpose
Fix to ensure solver has enough time to sync prior to the Results
Setting page being loaded.

## Related Issues
Closes BHP1-1618

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
- [x] Verify that a new worksheet with at least 2 multi-valued inputs shows the graphs in the Print view.