### PR TITLE
[BHP1-1615] Round graph settings maximum up to next whole number

### DIFF
--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -85,6 +85,14 @@
            (< normalized 7)   5
            :else              10)))))
 
+(defn default-y-axis-max
+  "Obtain a rounded max Y axis value for Graph Settings."
+  [max-val]
+  (let [y-max (+ max-val (nice-step-size max-val))]
+    (if (< y-max 1)
+      (/ (Math/ceil (* y-max 10)) 10)
+      (Math/ceil y-max))))
+
 ;;; Events
 
 (rf/reg-fx :ws/import-worksheet import-worksheet)
@@ -441,9 +449,7 @@
                   (let [[_min-to-use max-to-use] (if-let [direcitonal-parent-uuid (:bp/uuid (directional-parent-entity gv-uuid))]
                                                    (get output-min-max-values direcitonal-parent-uuid)
                                                    [min-val max-val])
-                        ;; FIX: BHP1-1532 - do not clip max values
-                        step                     (nice-step-size max-to-use)
-                        y-max                    (+ max-to-use step)]
+                        y-max                    (default-y-axis-max max-to-use)]
                     (-> acc
                         (conj [:dispatch [:worksheet/update-y-axis-limit-attr
                                           ws-uuid

--- a/projects/behave/test/cljs/behave/worksheet_events_test.cljs
+++ b/projects/behave/test/cljs/behave/worksheet_events_test.cljs
@@ -2,7 +2,7 @@
   (:require
    [behave.fixtures :as fx]
    [behave.test-utils :as utils]
-   [behave.worksheet.events]
+   [behave.worksheet.events :as events]
    [behave.worksheet.subs]
    [cljs.test :refer [deftest is join-fixtures testing use-fixtures are] :include-macros true]
    [datascript.core :as d]
@@ -382,3 +382,19 @@
 ;; =================================================================================================
 ;; :worksheet/update-furthest-visited-step
 ;; =================================================================================================
+
+;; =================================================================================================
+;; default-y-axis-max
+;; =================================================================================================
+
+(deftest default-y-axis-max-test
+  (testing "rounds up to the next whole number above 1 [BHP1-1615]"
+    (are [max-val expected] (= expected (events/default-y-axis-max max-val))
+      8.79 10
+      10.4 12
+      0    1))
+  (testing "rounds up to the next tenth below 1"
+    (is (= 0.5 (events/default-y-axis-max 0.43))))
+  (testing "never clips below max + nice step [BHP1-1532]"
+    (doseq [max-val [0.2 0.9 1.1 8.79 47.9 163.4]]
+      (is (> (events/default-y-axis-max max-val) max-val)))))


### PR DESCRIPTION
## Purpose

The default Graph Settings Maximum was `max result + nice step` as a raw float (e.g. Flame Length `10.839…`). Round it up to the next whole number (`11`) — or the next tenth for outputs below 1 — so graphs are not cut off and no extraneous digits are shown. Keeps the BHP1-1532 headroom (only ever rounds up).

## Related Issues
Closes BHP1-1615

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Create a Surface worksheet with a multi-value input (e.g. wind speed `5,10,15,20 mi/h`) and solve
2. Open `Graph Settings` on the results page
3. The `MAXIMUM` column shows whole numbers (e.g. Flame Length `10` instead of `9.79…`); outputs with results below 1 show one decimal (e.g. `0.8`)
4. `behave.worksheet-events-test/default-y-axis-max-test` covers the rounding and the no-clip invariant