### PR TITLE
[BHP1-1630] Fix VMS List Reorder

### DIFF
--- a/projects/behave_cms/src/cljs/behave_cms/events.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/events.cljs
@@ -314,17 +314,22 @@
 (reg-event-fx
  :api/reorder
  (fn [_ [_ entity all-entities order-field direction]]
-   (let [curr-order (get entity order-field)
-         sorted     (sort-by order-field all-entities)
-         next-order (condp = direction
-                      :inc (when (< curr-order (dec (count sorted)))
-                             (inc curr-order))
-                      :dec (when (> curr-order 0)
-                             (dec curr-order)))]
-     (when next-order
-       (let [swap (nth sorted next-order)]
-         {:transact [(assoc (select-keys swap [:db/id]) order-field curr-order)
-                     (assoc (select-keys entity [:db/id]) order-field next-order)]})))))
+   (let [sorted (vec (sort-by order-field all-entities))
+         pos    (first (keep-indexed
+                        (fn [i e] (when (= (:db/id e) (:db/id entity)) i))
+                        sorted))
+         target (case direction
+                  :inc (when (and pos (< pos (dec (count sorted)))) (inc pos))
+                  :dec (when (and pos (> pos 0)) (dec pos)))]
+     (when target
+       (let [swapped (assoc sorted
+                            pos    (nth sorted target)
+                            target (nth sorted pos))]
+         {:transact (vec (keep-indexed
+                          (fn [i e]
+                            (when (not= i (get e order-field))
+                              (assoc (select-keys e [:db/id]) order-field i)))
+                          swapped))})))))
 
 (reg-event-fx
  :scroll-into-view


### PR DESCRIPTION
-------

## Purpose

List reordering event does not properly handle cases when there are duplicate order values in the list. This update will account for this and is self cleaning, order of the list will be fixed upon changing the order of any list options.

## Related Issues
Closes BHP1-1630

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. get latest vms from dev
2. run this form and see that there are list options with duplicate values for `SurfaceFuelModels`. This form checks for all lists with such issues but only `SurfaceFuelModels` has it.

``` clojure
(do
    (require '[datomic.api               :as d]
             '[behave-cms.server         :as cms]
             '[behave-cms.store          :as store])

    (def conn (store/default-conn))

    (def db   (d/db conn))

    (defn duplicate-order-values-in-list
      [db lid]
      (let [opts (:list/options (d/entity db lid))]
        (->> opts
             (keep (fn [o]
                     (when-let [ord (:list-option/order o)]
                       [ord (:list-option/name o)])))
             (group-by first)
             (filter (fn [[_ v]] (> (count v) 1)))
             (map (fn [[ord v]] [ord (mapv second v)]))
             (into (sorted-map)))))

    ;; Scan every list; keep only the ones with collisions
    (->> (d/q '[:find [?l ...] :where [?l :list/name]] db)
         (keep (fn [lid]
                 (let [dups (duplicate-order-values-in-list db lid)]
                   (when (seq dups)
                     {:list                   (:list/name (d/entity db lid))
                      :option-count           (count (:list/options (d/entity db lid)))
                      :duplicate-order-values dups}))))
         (sort-by :list)
         clojure.pprint/pprint))
  ;; :=>{:list         "SurfaceFuelModels",
  ;;  :option-count 83,
  ;;  :duplicate-order-values
  ;;  {1
  ;;   ["FB2/2 - Timber grass and understory (Static)"
  ;;    "FB3/3 - Tall grass (Static)"],
  ;;   3
  ;;   ["GR2/102 - Low load dry climate grass (Dynamic)"
  ;;    "FB4/4 - Chaparral (Static)"],
  ;;   4
  ;;   ["FB5/5 - Brush (Static)"
  ;;    "GR3/103 - Low load very coarse, humid climate grass (Dynamic)"],
  ;;   5
  ;;   ["GR4/104 - Moderate load dry climate grass (Dynamic)"
  ;;    "FB6/6 - Dormant brush, hardwood slash (Static)"],
  ;;   6
  ;;   ["GR5/105 - Low load humid climate grass (Dynamic)"
  ;;    "FB7/7 - Southern rough (Static)"],
  ;;   7
  ;;   ["FB8/8 - Short needle litter (Static)"
  ;;    "GR6/106 - Moderate load humid climate grass (Dynamic)"],
  ;;   8
  ;;   ["FB9/9 - Long needle or hardwood litter (Static)"
  ;;    "GR7/107 - High load dry climate grass (Dynamic)"],
  ;;   9
  ;;   ["GR8/108 - High load very coarse, humid climate grass (Dynamic)"
  ;;    "FB10/10 - Timber litter & understory (Static)"],
  ;;   10
  ;;   ["FB11/11 - Light logging slash (Static)"
  ;;    "GR9/109 - Very high load humid climate grass (Dynamic)"],
  ;;   11
  ;;   ["FB12/12 - Medium logging slash (Static)"
     ;; "GS1/121 - Low load dry climate grass-shrub (Dynamic)"]}}
```

3. Open App and navigate to the list
4. Change an order of one list option
5. Run this form again, you should get an empty list now, and notice re-order is moving properly now

## Screenshots