### PR TITLE
[BHP1-1635] Fix Fire Shape Diagram

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/diagrams.cljs
+++ b/projects/behave/src/cljs/behave/components/results/diagrams.cljs
@@ -37,7 +37,7 @@
              [:tr
               [:td (str variable-name ":")]
               [:td (if (seq units)
-                     (str value " (" units ")")
+                     (str value " " units)
                      value)]])
            inputs)]
      [:table.diagram__table
@@ -45,7 +45,7 @@
              [:tr
               [:td (str variable-name ":")]
               [:td (if (seq units)
-                     (str value " (" units ")")
+                     (str value " " units)
                      value)]])
            outputs)]]))
 
@@ -105,7 +105,8 @@
                            ellipses            :worksheet.diagram/ellipses
                            arrows              :worksheet.diagram/arrows
                            scatter-plots       :worksheet.diagram/scatter-plots
-                           group-variable-uuid :worksheet.diagram/group-variable-uuid}]
+                           group-variable-uuid :worksheet.diagram/group-variable-uuid}
+                          print?]
 
   (let [scatter-plot-legacy?     (neg? (vu/compare-versions @(subscribe [:worksheet/version ws-uuid]) "7.1.5"))
         cms-diagram              @(subscribe [:wizard/diagram-by-gv-uuid group-variable-uuid])
@@ -144,10 +145,14 @@
                                                    :show-q4?      show-q4?})
         ;; Series (by translated legend label) that should start hidden/grayed in the
         ;; legend — any arrow flagged :arrow/default-visible? false (e.g. flanking).
-        hidden-by-default-series (into #{}
-                                       (comp (filter #(false? (:arrow/default-visible? %)))
-                                             (map (fn [a] @(<t (:arrow/legend-id a)))))
-                                       arrows)]
+        ;; In the print/PDF view every hideable component is always shown, so the
+        ;; hidden set is forced empty there.
+        hidden-by-default-series (if print?
+                                   #{}
+                                   (into #{}
+                                         (comp (filter #(false? (:arrow/default-visible? %)))
+                                               (map (fn [a] @(<t (:arrow/legend-id a)))))
+                                         arrows))]
     [:div.diagram
      [output-diagram {:title                    (build-title ws-uuid title row-id)
                       :width                    500
@@ -207,12 +212,13 @@
      (construct-summary-table ws-uuid group-variable-uuid row-id)]))
 
 (defn result-diagrams
-  "Reagent component rendering all diagrams for a worksheet."
-  [ws-uuid]
+  "Reagent component rendering all diagrams for a worksheet. When `print?` is truthy
+  (the PDF/print view), every legend-hideable component is forced visible."
+  [ws-uuid & [print?]]
   (let [*ws (subscribe [:worksheet-entity ws-uuid])]
     (when (seq (:worksheet/diagrams @*ws))
       [:div.wizard-results__diagrams {:id "diagram"}
        [:div.wizard-notes__header "Diagram"]
-       (map #(construct-diagram ws-uuid %)
+       (map #(construct-diagram ws-uuid % print?)
             (sort-by :worksheet.diagram/row-id
                      (:worksheet/diagrams @*ws)))])))

--- a/projects/behave/src/cljs/behave/components/vega/diagram.cljs
+++ b/projects/behave/src/cljs/behave/components/vega/diagram.cljs
@@ -4,6 +4,13 @@
             [clojure.string              :as str]
             [goog.string                 :as gstring]))
 
+(defn- ->vega-name
+  "Sanitize a legend label into a valid Vega expression identifier
+  (letters/digits/underscore only) so labels containing spaces, parentheses,
+  etc. can't be mis-parsed as function calls when used as param/signal names."
+  [legend-id]
+  (str/replace legend-id #"[^A-Za-z0-9]" "_"))
+
 (defn- ->str-literal
   "A double-quoted Vega expression string literal for `legend-id`, used in a
   `:calculate` transform to tag every row of a layer with a `series` field."
@@ -40,7 +47,7 @@
                   x-offset    0
                   dashed?     false
                   stroke-dash [1 0]}}]
-  (let [legend-id-cleaned (str/replace legend-id " " "_")
+  (let [legend-id-cleaned (->vega-name legend-id)
         a-name            (str "A_" legend-id-cleaned)
         b-name            (str "B_" legend-id-cleaned)
         phi-name          (str "PHI_" legend-id-cleaned)
@@ -92,7 +99,7 @@
                                  dashed?         false
                                  offset-distance 0
                                  offset-rotation 0}}]
-  (let [legend-id-cleaned (str/replace legend-id " " "_")
+  (let [legend-id-cleaned (->vega-name legend-id)
         r-name            (str "R_" legend-id-cleaned)
         theta-name        (str "THETA_" legend-id-cleaned)
         ;; Base point of the arrow, offset from the plot origin by

--- a/projects/behave/src/cljs/behave/print/views.cljs
+++ b/projects/behave/src/cljs/behave/print/views.cljs
@@ -1,11 +1,11 @@
 (ns behave.print.views
-  (:require [re-frame.core                          :refer [subscribe dispatch]]
-            [behave.print.subs]
+  (:require [behave.components.results.diagrams     :refer [result-diagrams]]
             [behave.components.results.graphs       :refer [result-graphs]]
-            [behave.components.results.diagrams     :refer [result-diagrams]]
-            [behave.components.results.matrices     :refer [result-matrices]]
             [behave.components.results.inputs.views :refer [inputs-table]]
-            [behave.components.results.table        :refer [pivot-tables search-tables]]))
+            [behave.components.results.matrices     :refer [result-matrices]]
+            [behave.components.results.table        :refer [pivot-tables search-tables]]
+            [behave.print.subs]
+            [re-frame.core                          :refer [subscribe dispatch]]))
 
 (defn- wizard-notes [notes]
   (when (seq notes)
@@ -24,12 +24,12 @@
 (defn print-page [{:keys [ws-uuid]}]
   (dispatch [:dev/close-after-print])
   (js/setTimeout #(dispatch [:dev/print]) 1000)
-  (let [worksheet           @(subscribe [:worksheet ws-uuid])
-        ws-date-created     (:worksheet/created worksheet)
-        ws-version          (:worksheet/version worksheet)
-        ws-description      (:worksheet/run-description worksheet)
-        notes               @(subscribe [:wizard/notes ws-uuid])
-        graph-data          @(subscribe [:worksheet/result-table-cell-data ws-uuid])]
+  (let [worksheet       @(subscribe [:worksheet ws-uuid])
+        ws-date-created (:worksheet/created worksheet)
+        ws-version      (:worksheet/version worksheet)
+        ws-description  (:worksheet/run-description worksheet)
+        notes           @(subscribe [:wizard/notes ws-uuid])
+        graph-data      @(subscribe [:worksheet/result-table-cell-data ws-uuid])]
     [:div.print
      [:div.print__header
       [:img {:src "/images/logo.svg"}]
@@ -49,4 +49,4 @@
       [pivot-tables ws-uuid]
       [result-matrices ws-uuid]
       [result-graphs ws-uuid graph-data]
-      [result-diagrams ws-uuid]]]))
+      [result-diagrams ws-uuid true]]]))

--- a/projects/behave_cms/resources/migrations/2026_08_19_auto_enable_fire_shape_outputs.clj
+++ b/projects/behave_cms/resources/migrations/2026_08_19_auto_enable_fire_shape_outputs.clj
@@ -1,0 +1,66 @@
+(ns migrations.2026-08-19-auto-enable-fire-shape-outputs
+  (:require [datomic.api              :as d]
+            [schema-migrate.interface :as sm]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; The Fire Shape diagram's summary table only renders an output row if that output
+;; was enabled/computed on the worksheet. The consolidated rework migration
+;; 2026_08_04_fire_shape_diagram.clj force-enables the directional spread-distance
+;; outputs (via `spread-distance-force-actions`) so they appear whenever the Fire
+;; Shape diagram is selected, but it never did the same for the pre-existing scalar
+;; fire-size outputs. This migration adds the analogous force-actions for fire area,
+;; fire perimeter, and length-to-width ratio so they auto-appear in the summary
+;; table too.
+;;
+;; These three have been in the diagram's :diagram/output-group-variables since the
+;; base seed, so no change to that list is needed. Because they are scalar values
+;; (no drawn arrow), they are gated on the diagram-selected condition only — the
+;; "heading" pattern, not the flanking/backing arrow gate.
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defn payload-fn [db]
+  (let [fs-cond {:conditional/group-variable-uuid (sm/t-key->uuid db "behaveplus:surface:output:size:surface___fire_size:fire-shape-diagram")
+                 :conditional/type                :group-variable
+                 :conditional/operator            :equal
+                 :conditional/values              #{"true"}}
+        specs   [["behaveplus:surface:output:size:surface___fire_size:fire_area"
+                  "fire-shape-diagram: force fire area"]
+                 ["behaveplus:surface:output:size:surface___fire_size:fire_perimeter"
+                  "fire-shape-diagram: force fire perimeter"]
+                 ["behaveplus:surface:output:size:surface___fire_size:length-to-width-ratio"
+                  "fire-shape-diagram: force length-to-width ratio"]]]
+    (mapv (fn [[k action-name]]
+            {:db/id                  (sm/t-key->eid db k)
+             :group-variable/actions [{:action/name                  action-name
+                                       :action/type                  :select
+                                       :action/conditionals-operator :and
+                                       :action/conditionals          #{fs-cond}}]})
+          specs)))
+
+;; ===========================================================================================================
+;; Manual REPL usage
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:duplicate-require :missing-docstring :unresolved-namespace]}
+(comment
+  (require '[behave-cms.server        :as cms])
+  (cms/init-db!)
+
+  (def conn (behave-cms.store/default-conn))
+
+  (try (def tx-data @(d/transact conn (payload-fn (d/db conn))))
+       (catch Exception e (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; Rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn tx-data))

--- a/projects/behave_cms/resources/migrations/2026_08_19_auto_enable_fire_shape_outputs.clj
+++ b/projects/behave_cms/resources/migrations/2026_08_19_auto_enable_fire_shape_outputs.clj
@@ -34,7 +34,7 @@
                   "fire-shape-diagram: force fire area"]
                  ["behaveplus:surface:output:size:surface___fire_size:fire_perimeter"
                   "fire-shape-diagram: force fire perimeter"]
-                 ["behaveplus:surface:output:size:surface___fire_size:length-to-width-ratio"
+                 ["behaveplus:surface:output:size:surface___fire_size:length_to_width_ratio"
                   "fire-shape-diagram: force length-to-width ratio"]]]
     (mapv (fn [[k action-name]]
             {:db/id                  (sm/t-key->eid db k)

--- a/projects/behave_cms/resources/migrations/2026_08_20_update_fire_shape_legend_labels.clj
+++ b/projects/behave_cms/resources/migrations/2026_08_20_update_fire_shape_legend_labels.clj
@@ -1,0 +1,49 @@
+(ns migrations.2026-08-20-update-fire-shape-legend-labels
+  (:require [datomic.api              :as d]
+            [schema-migrate.interface :as sm]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; Rename three Fire Shape diagram legend labels (en-US), originally set by
+;; 2026_08_04_fire_shape_diagram.clj:
+;;   - "Surface Fire Spread" -> "Resultant Vector"
+;;   - "Flanking 1 Fire"     -> "Flanking (Right)"
+;;   - "Flanking 2 Fire"     -> "Flanking (Left)"
+;;
+;; All three translation keys already exist, so sm/upsert-translations updates them
+;; in place (update-if-present / create-if-absent), scoped to the en-US language.
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defn payload-fn [db]
+  (sm/upsert-translations
+   db "en-US"
+   {"behaveplus:diagram:surface_fire_shape:legend_id:surface_fire_spread" "Resultant Vector"
+    "behaveplus:diagram:wind_slope_spread_direction:legend_id:flanking_1" "Flanking (Right)"
+    "behaveplus:diagram:wind_slope_spread_direction:legend_id:flanking_2" "Flanking (Left)"}))
+
+;; ===========================================================================================================
+;; Manual REPL usage
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:duplicate-require :missing-docstring :unresolved-namespace]}
+(comment
+  (require '[behave-cms.server        :as cms])
+  (cms/init-db!)
+
+  (def conn (behave-cms.store/default-conn))
+
+  (try (def tx-data @(d/transact conn (payload-fn (d/db conn))))
+       (catch Exception e (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; Rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn tx-data))

--- a/projects/behave_cms/src/cljs/behave_cms/components/common.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/components/common.cljs
@@ -241,12 +241,15 @@
 
   `opts` can take:
   - `size` - Button size (e.g. `:sm`/`:md`/`:lg`)
-  - `icon` - Font Awesome icon name to display to the left of the label."
-  [style label action & [{:keys [icon size]}]]
+  - `icon` - Font Awesome icon name to display to the left of the label.
+  - `btn-type` - Button `type` attribute (defaults to `\"button\"` so the button does
+                 not act as an implicit form submit when nested inside a `<form>`)."
+  [style label action & [{:keys [icon size btn-type]}]]
   [:button {:class    ["btn"
                        (when style (str "btn-" (name style)))
                        (when size (str "btn-" (name size)))
                        "mx-1"]
+            :type     (or btn-type "button")
             :on-click action}
    (when icon
      [:span {:class ["fa-solid" (str "fa-" icon)]}])

--- a/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/components/entity_form.cljs
@@ -55,10 +55,16 @@
                    (set/difference old-values new-values)))))
          (apply concat))))
 
-(defn- retract-cardinality-many-values [new-data original]
+(defn- retract-cardinality-many-values [new-data original set-field-keys]
   (let [cardinality-many-attrs (->> original
                                     (keys)
-                                    (filter db-cardinality-many-attrs))]
+                                    (filter db-cardinality-many-attrs)
+                                    ;; Only diff/retract attrs the form actually
+                                    ;; manages via editor state (`:set` fields).
+                                    ;; Ref lists edited out-of-band (e.g.
+                                    ;; :diagram/output-group-variables) must never
+                                    ;; be retracted here.
+                                    (filter (set set-field-keys)))]
     (if-not (seq cardinality-many-attrs)
       new-data
       (into [new-data]
@@ -481,46 +487,47 @@
                 :on-create     #(assoc % :submodule/order num-submodules)})
   ```"
   [{:keys [entity parent-field parent-id fields id on-create on-update state-path]}]
-  (let [state-path   (or state-path [:editors entity parent-id id])
-        original     @(rf/subscribe [:entity id])
-        parent       @(rf/subscribe [:entity parent-id])
-        update-state (fn [field] (fn [value] (rf/dispatch [:state/set-state (conj state-path field) value])))
-        get-state    (fn [field] (r/track #(let [result (cond
-                                                          (not (nil? @(rf/subscribe [:state (conj state-path field)])))
-                                                          @(rf/subscribe [:state (conj state-path field)])
+  (let [state-path     (or state-path [:editors entity parent-id id])
+        original       @(rf/subscribe [:entity id])
+        parent         @(rf/subscribe [:entity parent-id])
+        update-state   (fn [field] (fn [value] (rf/dispatch [:state/set-state (conj state-path field) value])))
+        get-state      (fn [field] (r/track #(let [result (cond
+                                                            (not (nil? @(rf/subscribe [:state (conj state-path field)])))
+                                                            @(rf/subscribe [:state (conj state-path field)])
 
-                                                          (not (nil? (:db/id (get original field))))
-                                                          (:db/id (get original field))
+                                                            (not (nil? (:db/id (get original field))))
+                                                            (:db/id (get original field))
 
-                                                          (not (nil? (get original field)))
-                                                          (get original field)
+                                                            (not (nil? (get original field)))
+                                                            (get original field)
 
-                                                          :else
-                                                          "")]
-                                             result)))
-        on-submit    (u/on-submit #(let [state @(rf/subscribe [:state state-path])]
-                                     (cond-> state
-                                       :always
-                                       (dissoc :group-variable-lookup)
+                                                            :else
+                                                            "")]
+                                               result)))
+        set-field-keys (->> fields (filter (fn [f] (= :set (:type f)))) (map :field-key))
+        on-submit      (u/on-submit #(let [state @(rf/subscribe [:state state-path])]
+                                       (cond-> state
+                                         :always
+                                         (dissoc :group-variable-lookup)
 
-                                       id
-                                       (merge {:db/id id})
+                                         id
+                                         (merge {:db/id id})
 
-                                       (and id (fn? on-update))
-                                       (on-update)
+                                         (and id (fn? on-update))
+                                         (on-update)
 
-                                       (and (nil? id) parent-field parent-id)
-                                       (merge-parent-fields original entity parent-field parent-id parent)
+                                         (and (nil? id) parent-field parent-id)
+                                         (merge-parent-fields original entity parent-field parent-id parent)
 
-                                       (and (nil? id) (fn? on-create))
-                                       (on-create)
+                                         (and (nil? id) (fn? on-create))
+                                         (on-create)
 
-                                       (and id (cardinality-many-fields? fields state))
-                                       (retract-cardinality-many-values original)
+                                         (and id (cardinality-many-fields? fields state))
+                                         (retract-cardinality-many-values original set-field-keys)
 
-                                       :always
-                                       (upsert-entity!))
-                                     (rf/dispatch [:state/set-state state-path nil])))]
+                                         :always
+                                         (upsert-entity!))
+                                       (rf/dispatch [:state/set-state state-path nil])))]
     [:form {:on-submit on-submit}
      #_{:clj-kondo/ignore [:shadowed-var]}
      (for [{:keys [field-key type] :as field} fields]


### PR DESCRIPTION
-------

## Purpose

1. Ensure Fire Area, Fire Perimeter, and Length to Width Ratio is enabled when Fire Shape Diagram is an output, it should now show up in the summary table.
2. Remove parens from units in the diagram summary tables
3. Update Legend Translations
3. Ensure in print mode, any components of the diagram that can be hidden shown
4. Fix Bug in cms where clicking Add entry to the diagram's output variable list wrongfully deletes the entries

## Related Issues
Closes BHP1-1635

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

### Testing App
1. Open local vms and have migrations ran
2. Open this worksheet: 
[BHP1-1635.zip](https://github.com/user-attachments/files/31282919/BHP1-1635.zip)

3. Navigate to results and ensure:

- Legend has updated text
- Fire Area, Fire Perimeter, and Length to Width Ratio  are shown
-  parens are removed from units in the diagram summary tables

4. Click Print
5. Ensure the Resultant Vector and Flanking arrows are shown

### Testing VMS

1. Navigate to the Fire Shape Diagram section
2. Click on Edit to show the form
3. Click Add Entry for the Output Group Variables table
4. Ensure the existing list did not get deleted

## Screenshots