### PR TITLE
BHP1-1526 Show each repeat group item as singular (Resource #1)

### DIFF
--- a/bases/behave_schema/src/behave/schema/group.cljc
+++ b/bases/behave_schema/src/behave/schema/group.cljc
@@ -32,6 +32,14 @@
                                    :group/research?
                                    :group/conditionals]))
 
+;;; Translation Keys
+
+(defn repeat-translation-key
+  "Translation key for a single item of a repeating group, e.g.
+  \"…:resources\" -> \"…:resources:repeat\"."
+  [translation-key]
+  (str translation-key ":repeat"))
+
 ;;; Schema
 
 #_{:clj-kondo/ignore [:missing-docstring]}

--- a/projects/behave/src/cljs/behave/components/input_group.cljs
+++ b/projects/behave/src/cljs/behave/components/input_group.cljs
@@ -2,7 +2,7 @@
   (:require [behave.components.core          :as c]
             [behave.components.unit-selector :refer [unit-display]]
             [goog.string                     :as gstring]
-            [behave.translate                :refer [<t bp]]
+            [behave.translate                :refer [<t bp repeat-item-name]]
             [behave.utils                    :refer [inclusive-range]]
             [clojure.string                  :as str]
             [data-utils.core                 :refer-macros [vmap]]
@@ -266,7 +266,8 @@
                                              (deref)
                                              (sort))
         next-repeat-id                   (or  (some->> repeat-ids seq (apply max) inc)
-                                              0)]
+                                              0)
+        item-name                        (repeat-item-name group-translation-key)]
     [:<>
      (map-indexed
       (fn [index repeat-id]
@@ -274,7 +275,7 @@
         [:<>
          [:div.wizard-repeat-group
           [:div.wizard-repeat-group__header
-           (str @(<t group-translation-key) " #" (inc index))]]
+           (str item-name " #" (inc index))]]
          [:div.wizard-group__inputs
           (for [variable variables]
             ^{:key (:db/id variable)}
@@ -291,7 +292,7 @@
                     :align-items     "center"
                     :justify-content "center"}}
       [c/button {:variant  "primary"
-                 :label    "Add Resource"
+                 :label    (str @(<t (bp "add")) " " item-name)
                  :on-click #(rf/dispatch [:worksheet/add-input-group ws-uuid group-uuid next-repeat-id])}]]]))
 
 (defn input-group [{:keys [workflow] :as params} group variables level]

--- a/projects/behave/src/cljs/behave/components/results/inputs/views.cljs
+++ b/projects/behave/src/cljs/behave/components/results/inputs/views.cljs
@@ -2,7 +2,7 @@
   (:require [behave.components.core :as c]
             [behave.components.results.inputs.subs]
             [behave.print.subs]
-            [behave.translate       :refer [<t]]
+            [behave.translate       :refer [<t repeat-item-name]]
             [clojure.string         :as str]
             [goog.string            :as gstring]
             [re-frame.core          :refer [subscribe]]))
@@ -65,7 +65,7 @@
                                                               (deref)
                                                               (sort))]
                                            (mapcat (fn [repeat-id]
-                                                     (into [{:input (indent-name (inc level) (str @(<t (:group/translation-key current-group)) " " (inc repeat-id)))}]
+                                                     (into [{:input (indent-name (inc level) (str (repeat-item-name (:group/translation-key current-group)) " " (inc repeat-id)))}]
                                                            (flatten
                                                             (for [variable (sort-by :group-variable/order variables)
                                                                   :let     [gv-uuid (:bp/uuid variable)

--- a/projects/behave/src/cljs/behave/translate.cljs
+++ b/projects/behave/src/cljs/behave/translate.cljs
@@ -1,5 +1,6 @@
 (ns behave.translate
-  (:require [re-frame.core :refer [dispatch-sync subscribe]]))
+  (:require [behave.schema.group :refer [repeat-translation-key]]
+            [re-frame.core       :refer [dispatch-sync subscribe]]))
 
 ;;; Configuration
 
@@ -27,6 +28,13 @@
   ```"
   [translation-key]
   (subscribe [:t translation-key]))
+
+(defn repeat-item-name
+  "Name for a single item of a repeating group (\"Resource\"), falling back to the
+  group's own translation (\"Resources\") when the repeat translation is unset."
+  [translation-key]
+  (or @(<t (repeat-translation-key translation-key))
+      @(<t translation-key)))
 
 (defn load-translations! []
   (let [browser   (browser-lang)

--- a/projects/behave_cms/resources/migrations/2026_08_20_add_repeat_group_item_translations.clj
+++ b/projects/behave_cms/resources/migrations/2026_08_20_add_repeat_group_item_translations.clj
@@ -1,0 +1,79 @@
+(ns migrations.2026-08-20-add-repeat-group-item-translations
+  (:require [behave.schema.group      :refer [repeat-translation-key]]
+            [datomic.api              :as d]
+            [schema-migrate.interface :as sm]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; BHP1-1526 — Repeat group items read plural ("Resources #1"); they should read
+;; singular ("Resource #1").
+;;
+;; An item's name is a translation keyed "<group translation-key>:repeat" (see
+;; behave.schema.group/repeat-translation-key). This adds it for every repeat
+;; group — today only Contain > Suppression > Resources — deriving the singular
+;; by dropping a trailing "s". Irregular ones can be fixed in the CMS under
+;; Group > Translations > Repeat Item Translations.
+;;
+;; After this runs, re-export layout.msgpack.
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+(defn- singular
+  "Naive singular of `s`: drops a trailing \"s\"."
+  [s]
+  (cond-> s
+    (re-find #"s$" s) (subs 0 (dec (count s)))))
+
+(defn- repeat-groups
+  "Translation keys of every group that repeats."
+  [db]
+  (d/q '[:find [?k ...]
+         :where
+         [?g :group/repeat? true]
+         [?g :group/translation-key ?k]]
+       db))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defn payload-fn [db]
+  (->> (repeat-groups db)
+       (reduce (fn [acc t-key]
+                 (let [translation (d/q '[:find ?t . :in $ ?k
+                                          :where
+                                          [?e :translation/key ?k]
+                                          [?e :translation/translation ?t]]
+                                        db t-key)]
+                   (cond-> acc
+                     translation
+                     (assoc (repeat-translation-key t-key) (singular translation)))))
+               {})
+       (sm/upsert-translations db "en-US")
+       (vec)))
+
+;; ===========================================================================================================
+;; Manual REPL usage
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:duplicate-require :missing-docstring :unresolved-namespace]}
+(comment
+  (require '[behave-cms.server :as cms]
+           '[behave-cms.store  :as store])
+  (cms/init-db!)
+
+  (def conn (store/default-conn))
+
+  (payload-fn (d/db conn))
+
+  (try (def tx-data @(d/transact conn (payload-fn (d/db conn))))
+       (catch Exception e (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; Rollback.
+;; ===========================================================================================================
+
+(comment
+  (require '[schema-migrate.interface :as sm])
+  (sm/rollback-tx! conn tx-data))

--- a/projects/behave_cms/src/cljs/behave_cms/subgroups/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/subgroups/views.cljs
@@ -9,6 +9,7 @@
             [behave-cms.help.views                    :refer [help-editor]]
             [behave-cms.subs]
             [behave-cms.utils                         :as u]
+            [behave.schema.group                      :refer [repeat-translation-key]]
             [clojure.set                              :refer [difference]]
             [clojure.string                           :as str]
             [re-frame.core                            :as rf]
@@ -135,7 +136,11 @@
         [:h5 "Worksheet Translations"]
         [all-translations (:group/translation-key @group)]
         [:h5 "Result Translations"]
-        [all-translations (:group/result-translation-key @group)]]
+        [all-translations (:group/result-translation-key @group)]
+        (when (:group/repeat? @group)
+          [:<>
+           [:h5 "Repeat Item Translations"]
+           [all-translations (repeat-translation-key (:group/translation-key @group))]])]
        [:hr]
        ^{:key "help"}
        [accordion


### PR DESCRIPTION
## Purpose

Fix Repeat Group items to be singular.

Adds a `<group translation-key>:repeat` translation, editable in the CMS under
Group -> Translations -> Repeat Item Translations (shown only for repeat groups).

## Related Issues
Closes BHP1-1526

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Start the VMS, sync with the app.
2. Contain worksheet -> Suppression -> Resources -> Click `Add Resource` twice. Items should read `Resource #1` and `Resource #2`.
3. Sub-group header still reads "Resources"; button still reads "Add Resource".
4. Run the worksheet, verify that the results show rows reading "Resource 1", "Resource 2".
5. In the VMS, check that "Repeat Item Translations" appears for the Resource group