### PR TITLE
[BHP1-1636] Fix Units Not Showing Up on Table Shading Filter Form

### DIFF
--- a/projects/behave/src/cljs/behave/components/settings_form/views.cljs
+++ b/projects/behave/src/cljs/behave/components/settings_form/views.cljs
@@ -59,10 +59,10 @@
         names                          (map (fn [[gv-uuid _min _max]]
                                               (gstring/format "%s (%s)"
                                                               @(subscribe [:wizard/gv-uuid->resolve-result-variable-name gv-uuid])
-                                                              (get units-lookup
-                                                                   (if-let [directional-children (seq @(subscribe [:vms/directional-children gv-uuid]))]
-                                                                     (:bp/uuid (first directional-children))
-                                                                     gv-uuid))))
+                                                              (let [child-uuids (map :bp/uuid @(subscribe [:vms/directional-children gv-uuid]))]
+                                                                (if (seq child-uuids)
+                                                                  (some units-lookup child-uuids)
+                                                                  (get units-lookup gv-uuid)))))
                                             gv-uuid+min+max-entries-sorted)
         checkboxes                     (when on-toggle-row
                                          (map (fn [[gv-uuid _min _max row-enabled?]]


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-1636

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. create a surface worksheet
2. Enable: 
- Heading Direction
- Fireline Intensity

3. Complete worksheet and navigate to settings page
4. Ensure there are units for Fireline Intensity in the Table Settings Filter table
5. Go back to outputs and change direction mode to Direction of Interest
6. Repeat steps 3-4


## Screenshots