### PR TITLE
[BHP1-1598] ensure legend shows full label

### DIFF
--- a/projects/behave/src/cljs/behave/components/vega/diagram.cljs
+++ b/projects/behave/src/cljs/behave/components/vega/diagram.cljs
@@ -231,6 +231,9 @@
                                                         :symbolType        "stroke"
                                                         :symbolSize        500
                                                         :symbolStrokeWidth 5.0
+                                                      ;; 0 = no truncation; show full label text
+                                                      ;; (default labelLimit of 200px cuts off long labels)
+                                                        :labelLimit        0
                                                       ;; gray out the legend entry of any series
                                                       ;; that has been toggled off (unselected)
                                                         :unselectedOpacity 0.35

--- a/projects/behave/src/cljs/behave/components/vega/diagram.cljs
+++ b/projects/behave/src/cljs/behave/components/vega/diagram.cljs
@@ -232,7 +232,6 @@
                                                         :symbolSize        500
                                                         :symbolStrokeWidth 5.0
                                                       ;; 0 = no truncation; show full label text
-                                                      ;; (default labelLimit of 200px cuts off long labels)
                                                         :labelLimit        0
                                                       ;; gray out the legend entry of any series
                                                       ;; that has been toggled off (unselected)


### PR DESCRIPTION
-------

## Purpose

## Related Issues
Closes BHP1-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [x] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. open this worksheet: 
[BHP1-1598.zip](https://github.com/user-attachments/files/31528099/BHP1-1598.zip)

2. Navigate to results and ensure the legend for the diagrams do not cut off.

## Screenshots