### PR TITLE
Fix size of pop-out graphs for 3 Multi-Valued Inputs

### DIFF
--- a/projects/behave/src/cljs/behave/components/results/graphs.cljs
+++ b/projects/behave/src/cljs/behave/components/results/graphs.cljs
@@ -60,14 +60,35 @@
      :width  width
      :height height}))
 
+(def ^:private facet-columns 2)
+
+(def ^:private legend-width 260)
+
+(defn- facet-grid
+  "[cols rows] of the z2 facet grid, or [1 1] when unfaceted."
+  [graph-settings data]
+  (if-let [z2-uuid (:graph-settings/z2-axis-group-variable-uuid graph-settings)]
+    (let [z2-name @(subscribe [:wizard/gv-uuid->resolve-result-variable-name z2-uuid])
+          facets  (max 1 (count (distinct (keep #(get % z2-name) data))))
+          cols    (min facets facet-columns)]
+      [cols (js/Math.ceil (/ facets cols))])
+    [1 1]))
+
 (defmethod modal-content :graph
   [{:keys [ws-uuid output-uuid]}]
   (let [graph-settings @(subscribe [:worksheet/graph-settings ws-uuid])
         cell-data      @(subscribe [:worksheet/result-table-cell-data ws-uuid])
-        [width height] (pop-out-size)]
+        data           (cell-data->graph-data cell-data)
+        [box-w box-h]  (pop-out-size)
+        [cols rows]    (facet-grid graph-settings data) ; width/height are per facet cell, so divide by grid
+        legend         (if (:graph-settings/z-axis-group-variable-uuid graph-settings)
+                         legend-width
+                         0)
+        width          (max 200 (quot (- box-w legend) cols))
+        height         (max 150 (quot (- box-h (* 60 rows)) rows))]
     [:div.wizard-results__graph-pop-out
      [vega-box (build-line-chart (chart-spec {:graph-settings graph-settings
-                                              :data           (cell-data->graph-data cell-data)
+                                              :data           data
                                               :output-uuid    output-uuid
                                               :width          width
                                               :height         height}))
@@ -76,8 +97,8 @@
 (defn result-graphs
   "Renders the Results graphs for the worksheet `ws-uuid`.
 
-  `:hide-controls?` omits the on-screen-only controls (Graph Settings, pop-out),
-  which have nothing to act on outside the app — e.g. on the printed page."
+  `:hide-controls?` omits the on-screen-only controls (Graph Settings, pop-out) —
+  e.g. on the printed page."
   [ws-uuid cell-data & [{:keys [hide-controls?]}]]
   (let [graph-enabled? @(subscribe [:wizard/enable-graph-settings? ws-uuid])
         graph-settings @(subscribe [:worksheet/graph-settings ws-uuid])]


### PR DESCRIPTION
## Purpose
EOM

## Related Issues
Closes BHP1-1363

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. Load the following worksheet:
[ranged_fuel_moisture_wind_fuel_models.bp7.zip](https://github.com/user-attachments/files/31705355/ranged_fuel_moisture_wind_fuel_models.bp7.zip)

2. Verify that enlarged graphs don't extend beyond the pop-out window

## Screenshots
<img width="1109" height="864" alt="Screenshot 2026-09-01 at 11 20 10 AM" src="https://github.com/user-attachments/assets/2cb896e7-ccad-4730-9dfd-b9a9e89aed9c" />
