### PR TITLE
BHP1-1363 Fix pop-out sometimes not opening

### DIFF
--- a/projects/behave/src/cljs/behave/events.cljs
+++ b/projects/behave/src/cljs/behave/events.cljs
@@ -13,6 +13,25 @@
             [re-frame.core                 :as rf]
             [vimsical.re-frame.cofx.inject :as inject]))
 
+;;; Guards
+
+(rf/reg-global-interceptor
+ (rf/->interceptor
+  :id    ::map-effects
+  :after (fn [context]
+           ;; A non-map return throws in `do-fx`, and re-frame answers by purging
+           ;; the whole pending queue -- silently dropping unrelated events.
+           (let [effects (:effects context)]
+             (if (or (nil? effects) (map? effects))
+               context
+               (do
+                 (rf/console :error
+                             "re-frame: event"
+                             (get-in context [:coeffects :event])
+                             "returned a non-map effects value; ignoring it:"
+                             effects)
+                 (assoc context :effects {})))))))
+
 ;;; Initialization
 
 (def initial-state {:router       {:history       []
@@ -144,7 +163,8 @@
  :system/add-script
  (fn [_ [_ src]]
    (when-not (script-exist? src)
-     (add-script src {:crossorigin "anonymous"}))))
+     (add-script src {:crossorigin "anonymous"}))
+   {}))
 
 (rf/reg-event-fx
  :system/close
@@ -196,19 +216,23 @@
 (rf/reg-event-fx
  :dev/print
  (fn [_]
-   (js/window.print)))
+   (js/window.print)
+   {}))
 
 (rf/reg-event-fx
  :dev/close-after-print
  (fn [_]
-   (.addEventListener js/window "afterprint" #(.close js/window))))
+   (.addEventListener js/window "afterprint" #(.close js/window))
+   {}))
 
 (rf/reg-event-fx
  :app/reload
  (fn [_ _]
-   (js/window.location.reload)))
+   (js/window.location.reload)
+   {}))
 
 (rf/reg-event-fx
  :toolbar/print
  (fn [_ [_ ws-uuid]]
-   (.open js/window (str "/worksheets/" ws-uuid "/print"))))
+   (.open js/window (str "/worksheets/" ws-uuid "/print"))
+   {}))

--- a/projects/behave/src/cljs/behave/wizard/events.cljs
+++ b/projects/behave/src/cljs/behave/wizard/events.cljs
@@ -185,7 +185,8 @@
          section (.getElementById js/document id)
          buffer  (* 0.01 (.-offsetHeight content))
          top     (- (.-offsetTop section) (.-offsetTop content) buffer)]
-     (.scroll content #js {:top top :behavior "smooth"}))))
+     (.scroll content #js {:top top :behavior "smooth"})
+     {})))
 
 (rf/reg-event-fx
  :wizard/delete
@@ -351,12 +352,14 @@
  :wizard/open
  (fn [_ [_ file]]
    (s/open-worksheet! {:file file})
-   (rf/clear-subscription-cache!)))
+   (rf/clear-subscription-cache!)
+   {}))
 
 (rf/reg-event-fx
  :wizard/new-worksheet
  (fn [_ [_ nname modules submodule workflow]]
-   (s/new-worksheet! nname modules submodule workflow)))
+   (s/new-worksheet! nname modules submodule workflow)
+   {}))
 
 (rf/reg-event-fx
  :wizard/toggle-expand

--- a/projects/behave/src/cljs/behave/wizard/views.cljs
+++ b/projects/behave/src/cljs/behave/wizard/views.cljs
@@ -586,8 +586,8 @@
                           :icon-name "settings"
                           :on-click  #(dispatch [:table-settings/toggle])}]])
             [result-matrices ws-uuid]])
-         (result-graphs ws-uuid @*cell-data)
-         (result-diagrams ws-uuid)]]
+         [result-graphs ws-uuid @*cell-data]
+         [result-diagrams ws-uuid]]]
        [:div.wizard-navigation
         [c/button {:label    @(<t (bp "back"))
                    :variant  "secondary"

--- a/projects/behave/src/cljs/behave/worksheet/events.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/events.cljs
@@ -108,7 +108,8 @@
 (rf/reg-event-fx
  :worksheet/solve
  (fn [_ [_ ws-uuid]]
-   (solve-worksheet ws-uuid)))
+   (solve-worksheet ws-uuid)
+   {}))
 
 (rp/reg-event-fx
  :worksheet/new


### PR DESCRIPTION
## Purpose
Re-Frame requires all effects to return a map (e.g.`{:state {:new
"update"} }`). When an event doesn't have that map, it causes the
ENTIRE event queue to get purged, even if other effects are behaving properly.


The reason why the modal didn't open was `[:modal/open ...]`was
sitting in the same batch as an effect with no map, discarding it with no warning.

Adds a global interceptor to catch effects with missing maps by logging the offending event id
and substitutes `{}`. That way one bad effect can't silently wipe the queue again. 

Also ensures other effects that were missing an empty returns an empty map.

## Related Issues
BHP1-1363

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Open the following worksheet: 
2. Verify that Modal opens on the Result page
3. Verify that Printing to PDF still works as expected