### PR TITLE
[BHP1-1637] Let outputs opt out of Table Shading Filters

### DIFF
--- a/bases/behave_schema/src/behave/schema/group_variable.cljc
+++ b/bases/behave_schema/src/behave/schema/group_variable.cljc
@@ -19,6 +19,7 @@
 (s/def :group-variable/translation-key     valid-key?)
 (s/def :group-variable/research?           boolean?)
 (s/def :group-variable/hide-graph?         boolean?)
+(s/def :group-variable/hide-table-filter?  boolean?)
 (s/def :group-variable/direction           valid-direction?)
 (s/def :group-variable/direction-variables (s/coll-of int?))
 
@@ -30,6 +31,7 @@
                                       :opt [:group-variable/research?
                                             :group-variable/direction-variables
                                             :group-variable/hide-graph?
+                                            :group-variable/hide-table-filter?
                                             :group-variable/direction
                                             :group-variable/cpp-class
                                             :group-variable/cpp-namespace
@@ -163,6 +165,11 @@
 
    {:db/ident       :group-variable/hide-graph?
     :db/doc         "Whether a Group Variable is excluded from being graphed."
+    :db/valueType   :db.type/boolean
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :group-variable/hide-table-filter?
+    :db/doc         "Whether a Group Variable is excluded from Table Shading Filters: no row on the Table Shading Filters page, and no in-range/out-of-range mark on Results."
     :db/valueType   :db.type/boolean
     :db/cardinality :db.cardinality/one}])
 

--- a/projects/behave/src/cljs/behave/components/results/matrices.cljs
+++ b/projects/behave/src/cljs/behave/components/results/matrices.cljs
@@ -86,23 +86,23 @@
                   :output-gv-uuid output-gv-uuid}])))
 
 (defn- build-matrix-data
-  [matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn shade-set any-filters-enabled?]
+  [matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn shade-set show-marks?]
   (reduce-kv
    (fn [acc [row col] value]
      (let [shaded? (contains? shade-set [row col])]
        (assoc acc [(row-fmt-fn row) (col-fmt-fn col)]
-              (format-matrix-cell value output-fmt-fn (when any-filters-enabled? shaded?)))))
+              (format-matrix-cell value output-fmt-fn (when show-marks? shaded?)))))
    {}
    matrix-data-raw))
 
 (defn- build-matrix-data-with-map-units
-  [{:keys [matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn output-units map-units map-rep-frac shade-set any-filters-enabled?]}]
+  [{:keys [matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn output-units map-units map-rep-frac shade-set show-marks?]}]
   (reduce-kv
    (fn [acc [row col] value]
      (let [shaded?         (contains? shade-set [row col])
            converted-value (convert-to-map-units value output-units map-units map-rep-frac)]
        (assoc acc [(row-fmt-fn row) (col-fmt-fn col)]
-              (format-matrix-cell converted-value output-fmt-fn (when any-filters-enabled? shaded?)))))
+              (format-matrix-cell converted-value output-fmt-fn (when show-marks? shaded?)))))
    {}
    matrix-data-raw))
 
@@ -150,11 +150,12 @@
    fold serves both outputs-on-rows and outputs-on-columns layouts. The raw data is always
    keyed [mvi-val output-uuid]. Returns [regular-data map-units-table-data]."
   [{:keys [matrix-data-raw input-fmt-fn formatters process-map-units? units-lookup
-           map-units map-rep-frac shade-set any-filters-enabled? place]}]
+           map-units map-rep-frac shade-set any-filters-enabled? unfilterable-uuids place]}]
   (reduce-kv
    (fn [[reg mu] [mvi-val output-uuid] v]
      (let [fmt-fn  (get formatters output-uuid identity)
-           shade   (when any-filters-enabled? (contains? shade-set mvi-val))
+           shade   (when (and any-filters-enabled? (not (contains? unfilterable-uuids output-uuid)))
+                     (contains? shade-set mvi-val))
            mvi-key (input-fmt-fn mvi-val)]
        [(assoc reg (place output-uuid mvi-key)
                (format-matrix-cell v fmt-fn shade))
@@ -233,7 +234,8 @@
                  :rows    map-units-rows}))]))
 
 (defmethod construct-result-matrices 1
-  [{:keys [ws-uuid process-map-units? multi-valued-inputs formatters output-entities units-lookup shade-set any-filters-enabled? title header-color cell-color-gv-uuid]}]
+  [{:keys [ws-uuid process-map-units? multi-valued-inputs formatters output-entities units-lookup shade-set
+           any-filters-enabled? unfilterable-uuids title header-color cell-color-gv-uuid]}]
   (let [[multi-var-name
          multi-var-units
          multi-var-gv-uuid
@@ -266,6 +268,7 @@
                                                          :map-rep-frac         rep-fraction
                                                          :shade-set            shade-set
                                                          :any-filters-enabled? any-filters-enabled?
+                                                         :unfilterable-uuids   unfilterable-uuids
                                                          :place                place})
         [results-table-column-headers
          map-units-table-column-headers
@@ -310,7 +313,7 @@
 
 (defmethod construct-result-matrices 2
   [{:keys [ws-uuid process-map-units? multi-valued-inputs formatters output-entities shade-set any-filters-enabled?
-           sub-title submatrix-value submatrix-gv-uuid header-color cell-color-gv-uuid]}]
+           unfilterable-uuids sub-title submatrix-value submatrix-gv-uuid header-color cell-color-gv-uuid]}]
   (let [graph-settings                              @(subscribe [:worksheet/graph-settings ws-uuid])
         table-settings                              @(subscribe [:worksheet/table-settings ws-uuid])
         row-axis-gv-uuid                            (or (:table-settings/row-group-variable-uuid table-settings)
@@ -356,22 +359,24 @@
                                                     :output-gv-uuid    output-gv-uuid
                                                     :submatrix-gv-uuid submatrix-gv-uuid
                                                     :submatrix-value   submatrix-value})
-             output-values   (map second matrix-data-raw)]
+             output-values   (map second matrix-data-raw)
+             show-marks?     (and any-filters-enabled?
+                                  (not (contains? unfilterable-uuids output-gv-uuid)))]
          (when-not (every? #(= "-1" %) output-values)
-           (let [matrix-data-formatted (build-matrix-data matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn shade-set any-filters-enabled?)]
+           (let [matrix-data-formatted (build-matrix-data matrix-data-raw row-fmt-fn col-fmt-fn output-fmt-fn shade-set show-marks?)]
              [:<>
               (when (process-map-units? output-gv-uuid)
                 [:div.print__result-table
-                 (let [data (build-matrix-data-with-map-units {:matrix-data-raw      matrix-data-raw
-                                                               :row-fmt-fn           row-fmt-fn
-                                                               :col-fmt-fn           col-fmt-fn
-                                                               :output-fmt-fn        output-fmt-fn
-                                                               :output-units         output-units
-                                                               :map-units            units
-                                                               :map-rep-frac         rep-fraction
-                                                               :shade-set            shade-set
-                                                               :any-filters-enabled? any-filters-enabled?
-                                                               :color-map            color-map})]
+                 (let [data (build-matrix-data-with-map-units {:matrix-data-raw matrix-data-raw
+                                                               :row-fmt-fn      row-fmt-fn
+                                                               :col-fmt-fn      col-fmt-fn
+                                                               :output-fmt-fn   output-fmt-fn
+                                                               :output-units    output-units
+                                                               :map-units       units
+                                                               :map-rep-frac    rep-fraction
+                                                               :shade-set       shade-set
+                                                               :show-marks?     show-marks?
+                                                               :color-map       color-map})]
                    (c/matrix-table {:title          (gstring/format @(<t (bp "s_map_units_(s)")) output-name units)
                                     :header-color   header-color
                                     :sub-title      sub-title
@@ -393,7 +398,8 @@
                                 :cell-colors    cell-colors})]]))))]))
 
 (defmethod construct-result-matrices 3
-  [{:keys [ws-uuid process-map-units? multi-valued-inputs formatters output-entities shade-set any-filters-enabled? units-lookup header-color cell-color-gv-uuid]}]
+  [{:keys [ws-uuid process-map-units? multi-valued-inputs formatters output-entities shade-set any-filters-enabled?
+           unfilterable-uuids units-lookup header-color cell-color-gv-uuid]}]
   (let [graph-settings                             @(subscribe [:worksheet/graph-settings ws-uuid])
         table-settings                             @(subscribe [:worksheet/table-settings ws-uuid])
         z2-axis-group-variable-uuid                (or (:table-settings/submatrix-group-variable-uuid table-settings)
@@ -426,7 +432,8 @@
           :header-color         header-color
           :cell-color-gv-uuid   cell-color-gv-uuid
           :shade-set            (get shade-set value)
-          :any-filters-enabled? any-filters-enabled?}]])]))
+          :any-filters-enabled? any-filters-enabled?
+          :unfilterable-uuids   unfilterable-uuids}]])]))
 
 ;;==============================================================================
 ;; Discrete Color Selector & Legend
@@ -492,7 +499,7 @@
         map-units-enabled?              (:map-units-settings/enabled? map-units-settings-entity)
         map-unit-convertible-variables  @(subscribe [:wizard/map-unit-convertible-variables])
         units-lookup                    @(subscribe [:worksheet/result-table-units ws-uuid])
-        table-setting-filters           @(subscribe [:worksheet/table-settings-filters ws-uuid])
+        table-setting-filters           @(subscribe [:worksheet/table-settings-filters-shadeable ws-uuid])
         gv-order                        @(subscribe [:vms/group-variable-order ws-uuid])
         pivot-tables                    @(subscribe [:worksheet/pivot-tables ws-uuid])
         directional-uuids               (set @(subscribe [:vms/directional-group-variable-uuids]))
@@ -515,7 +522,11 @@
         heading-gv-uuids                (when heading-direction
                                           (filter #(deref (subscribe [:vms/group-variable-is-directional? % heading-direction]))
                                                   directional-gv-uuids))
-        any-filters-enabled?            (boolean (some (fn [[_ _ _ enabled?]] enabled?) table-setting-filters))]
+        any-filters-enabled?            (boolean (some (fn [[_ _ _ enabled?]] enabled?) table-setting-filters))
+        ;; Outputs the Fire Lab opted out of shading: no filter row, and no
+        ;; in-range/out-of-range mark even when another output's filter is on.
+        unfilterable-uuids              (set (filter #(deref (subscribe [:vms/hide-table-filter? %]))
+                                                     all-output-gv-uuids))]
     (when (and (seq discrete-outputs-with-colors) (nil? color-output-state))
       (dispatch-sync [:wizard/set-discrete-color-output (:bp/uuid (first discrete-outputs-with-colors))]))
     (when (seq all-output-gv-uuids)
@@ -544,7 +555,8 @@
                :formatters           formatters
                :cell-color-gv-uuid   cell-color-gv-uuid
                :shade-set            @(subscribe [:worksheet/shade-set ws-uuid output-gv-uuids])
-               :any-filters-enabled? any-filters-enabled?}])))
+               :any-filters-enabled? any-filters-enabled?
+               :unfilterable-uuids   unfilterable-uuids}])))
        (when (seq non-directional-output-gv-uuids)
          (let [group-variables (map (fn [gv-uuid] @(subscribe [:wizard/group-variable gv-uuid])) non-directional-output-gv-uuids)
                output-entities (map (fn [gv] (merge gv {:units (get units-lookup (:bp/uuid gv))})) group-variables)
@@ -563,4 +575,5 @@
              :formatters           formatters
              :cell-color-gv-uuid   cell-color-gv-uuid
              :shade-set            @(subscribe [:worksheet/shade-set ws-uuid shade-scope])
-             :any-filters-enabled? any-filters-enabled?}]))])))
+             :any-filters-enabled? any-filters-enabled?
+             :unfilterable-uuids   unfilterable-uuids}]))])))

--- a/projects/behave/src/cljs/behave/components/results/pop_out.cljs
+++ b/projects/behave/src/cljs/behave/components/results/pop_out.cljs
@@ -1,0 +1,21 @@
+(ns behave.components.results.pop-out
+  "Shared bits for opening a Results chart in the pop-out modal."
+  (:require [behave.components.core :as c]
+            [re-frame.core          :refer [dispatch]]))
+
+(defn pop-out-size
+  "Chart size for the pop-out modal, bounded by the viewport."
+  []
+  (let [width  (min 1000 (max 300 (- (.-innerWidth js/window) 240)))
+        height (min 700 (max 250 (- (.-innerHeight js/window) 280)))]
+    [width height]))
+
+(defn pop-out-button
+  "Opens the `id` modal with `ctx`. Sits over a chart's top-right corner."
+  [id ctx]
+  [:div.pop-out-button
+   [c/button {:icon-name "pop-out"
+              :variant   "secondary"
+              :size      "small"
+              :title     "Enlarge"
+              :on-click  #(dispatch [:modal/open id ctx])}]])

--- a/projects/behave/src/cljs/behave/components/results/table.cljs
+++ b/projects/behave/src/cljs/behave/components/results/table.cljs
@@ -72,7 +72,7 @@
         cell-data                 (or cell-data @(subscribe [:worksheet/result-table-cell-data ws-uuid]))
         header-uuids              (map first headers)
         headers-set               (set header-uuids)
-        table-setting-filters     @(subscribe [:worksheet/table-settings-filters ws-uuid])
+        table-setting-filters     @(subscribe [:worksheet/table-settings-filters-shadeable ws-uuid])
         filters-by-uuid           (shading/filters-by-uuid table-setting-filters)
         sig-digits                @(subscribe [:worksheet/result-table-significant-digits header-uuids])
         directional-uuids         (set @(subscribe [:vms/directional-group-variable-uuids]))

--- a/projects/behave/src/cljs/behave/vms/subs.cljs
+++ b/projects/behave/src/cljs/behave/vms/subs.cljs
@@ -403,3 +403,23 @@
  (fn [_ [_ gv-uuid]]
    (directional-parent-entity gv-uuid)))
 
+(defn hide-table-filter-entity?
+  "Whether group-variable `entity` opts out of Table Shading Filters — no row on
+  the Table Shading Filters page and no in-range/out-of-range mark on Results.
+
+  A directional child inherits the flag from its parent, since the two share a
+  single filter range."
+  [entity]
+  (boolean (or (:group-variable/hide-table-filter? entity)
+               (:group-variable/hide-table-filter? (first (:group-variable/_direction-variables entity))))))
+
+(defn hide-table-filter?
+  "[[hide-table-filter-entity?]] for the group variable named by `gv-uuid`."
+  [gv-uuid]
+  (hide-table-filter-entity? (d/entity @@vms-conn [:bp/uuid gv-uuid])))
+
+(reg-sub
+ :vms/hide-table-filter?
+ (fn [_ [_ gv-uuid]]
+   (hide-table-filter? gv-uuid)))
+

--- a/projects/behave/src/cljs/behave/worksheet/subs.cljs
+++ b/projects/behave/src/cljs/behave/worksheet/subs.cljs
@@ -6,7 +6,8 @@
             [behave.translate            :refer [<t]]
             [behave.vms.store            :as vms :refer [vms-conn]]
             [behave.vms.subs             :refer [direction-variables
-                                                 directional-parent-entity]]
+                                                 directional-parent-entity
+                                                 hide-table-filter?]]
             [behave.wizard.subs          :refer [all-conditionals-pass?]]
             [clojure.set                 :as set]
             [clojure.string              :as str]
@@ -673,9 +674,21 @@
     :variables [ws-uuid]}))
 
 (rf/reg-sub
+ :worksheet/table-settings-filters-shadeable
+ (fn [[_ ws-uuid]]
+   [(rf/subscribe [:worksheet/table-settings-filters ws-uuid])
+    (rf/subscribe [:worksheet/output-uuids-conditionally-filtered ws-uuid])])
+ (fn [[table-settings-filters visible-output-uuids] _]
+   (let [visible? (set visible-output-uuids)]
+     (remove (fn [[group-var-uuid]]
+               (or (hide-table-filter? group-var-uuid)
+                   (not (visible? group-var-uuid))))
+             table-settings-filters))))
+
+(rf/reg-sub
  :worksheet/table-settings-filters-filtered
  (fn [[_ ws-uuid]]
-   [(rf/subscribe [:worksheet/table-settings-filters ws-uuid])])
+   [(rf/subscribe [:worksheet/table-settings-filters-shadeable ws-uuid])])
  (fn [[table-settings-filters] _]
    (remove
     (fn [[group-var-uuid]]
@@ -742,7 +755,7 @@
    [(rf/subscribe [:print/matrix-table-multi-valued-inputs ws-uuid])
     (rf/subscribe [:worksheet/table-settings ws-uuid])
     (rf/subscribe [:worksheet/graph-settings ws-uuid])
-    (rf/subscribe [:worksheet/table-settings-filters ws-uuid])])
+    (rf/subscribe [:worksheet/table-settings-filters-shadeable ws-uuid])])
  (fn [[multi-valued-inputs table-settings graph-settings table-setting-filters]
       [_ ws-uuid output-gv-uuids]]
    (let [filters    (shading/filters-by-uuid table-setting-filters)

--- a/projects/behave/test/cljs/behave/test_namespaces.cljs
+++ b/projects/behave/test/cljs/behave/test_namespaces.cljs
@@ -27,6 +27,7 @@
    [behave.tests-used-in-fixtures]
    [behave.units-test]
    [behave.utils-test]
+   [behave.vms-subs-test]
    [behave.vms.subs]
    [behave.wizard.events]
    [behave.wizard.subs]

--- a/projects/behave/test/cljs/behave/vms_subs_test.cljs
+++ b/projects/behave/test/cljs/behave/vms_subs_test.cljs
@@ -1,26 +1,39 @@
-(ns behave.vms-sub-test
-  (:require
-   [cljs.test :refer [use-fixtures deftest is join-fixtures] :include-macros true]
-   [re-frame.core :as rf]
-   [behave.fixtures :refer [setup-empty-db teardown-db]]))
+(ns behave.vms-subs-test
+  (:require [behave.vms.subs :refer [hide-table-filter-entity?]]
+            [cljs.test       :refer [deftest is testing]]
+            [datascript.core :as d]))
 
+;; A directional parent flagged `hide-table-filter?` plus its Heading/Backing
+;; children, and one unflagged non-directional output for contrast.
+(def ^:private test-db
+  (-> (d/create-conn {:bp/uuid                            {:db/unique :db.unique/identity}
+                      :group-variable/direction-variables {:db/valueType   :db.type/ref
+                                                           :db/cardinality :db.cardinality/many}})
+      (doto (d/transact!
+             [{:db/id   -1
+               :bp/uuid "crown-length-scorched-heading"}
+              {:db/id   -2
+               :bp/uuid "crown-length-scorched-backing"}
+              {:db/id                              -3
+               :bp/uuid                            "crown-length-scorched"
+               :group-variable/hide-table-filter?  true
+               :group-variable/direction-variables [-1 -2]}
+              {:bp/uuid "spread-rate"}]))
+      deref))
 
-;; =================================================================================================
-;; Test utils and fixtures
-;; =================================================================================================
+(defn- entity [gv-uuid]
+  (d/entity test-db [:bp/uuid gv-uuid]))
 
-(use-fixtures :each
-  {:before (join-fixtures [setup-empty-db])
-   :after  (join-fixtures [teardown-db])})
+(deftest hide-table-filter-entity?-test
+  (testing "a flagged group variable opts out of table shading filters"
+    (is (true? (hide-table-filter-entity? (entity "crown-length-scorched")))))
 
-;; =================================================================================================
-;; Tests
-;; =================================================================================================
+  (testing "direction children inherit the flag from their parent"
+    (is (true? (hide-table-filter-entity? (entity "crown-length-scorched-heading"))))
+    (is (true? (hide-table-filter-entity? (entity "crown-length-scorched-backing")))))
 
-(deftest vms-entity-test
-  (let [module @(rf/subscribe [:vms/entity-from-uuid "21ddce87-0809-4f9d-b2a7-9ef2d4881a3f"])]
-    (is (some? module))))
+  (testing "unflagged group variables keep their filter"
+    (is (false? (hide-table-filter-entity? (entity "spread-rate")))))
 
-(deftest vms-pull-with-attr-test
-  (let [module @(rf/subscribe [:vms/pull-with-attr :module/name])]
-    (is (some? module))))
+  (testing "an unknown group variable is not flagged"
+    (is (false? (hide-table-filter-entity? nil)))))

--- a/projects/behave_cms/resources/migrations/2026_08_26_hide_table_shading_filters.clj
+++ b/projects/behave_cms/resources/migrations/2026_08_26_hide_table_shading_filters.clj
@@ -1,0 +1,79 @@
+(ns ^{:migrate/ignore? true} migrations.2026-08-26-hide-table-shading-filters
+  (:require [behave-cms.server :as cms]
+            [behave-cms.store :refer [default-conn]]
+            [datomic.api :as d]
+            [schema-migrate.interface :as sm]))
+
+;; ===========================================================================================================
+;; Overview
+;; ===========================================================================================================
+
+;; BHP1-1637 — Table Shading Filters do not make sense for outputs users never
+;; base a decision on. Flag those outputs with
+;; `:group-variable/hide-table-filter?` so the app drops their row from the
+;; Table Shading Filters page and stops marking their result cells.
+;;
+;; After this runs, re-export layout.msgpack.
+
+;; ===========================================================================================================
+;; Initialize
+;; ===========================================================================================================
+
+(cms/init-db!)
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def conn (default-conn))
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def translation-keys
+  ["behaveplus:surface:output:size:surface___fire_size:length-to-width-ratio"
+   "behaveplus:surface:output:wind-and-fuel:wind:midflame-eye-level-wind-speed"
+   "behaveplus:surface:output:wind-and-fuel:fuel:total-live-fuel-load"
+   "behaveplus:surface:output:wind-and-fuel:fuel:total-dead-fuel-load"
+   "behaveplus:surface:output:wind-and-fuel:fuel:total-dead-herbaceous-fuel-load"
+   "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_length_scorched"
+   "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_length_scorched_backing"
+   "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_length_scorched_flanking"
+   "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_volume_scorched"
+   "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_volume_scorched_backing"
+   "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_volume_scorched_flanking"
+   "behaveplus:contain:output:fire:fire_size___at_resource_arrival_time:fire_perimeter___at_resource_arrival_time"
+   "behaveplus:contain:output:fire:fire_size___at_resource_arrival_time:fire_area___at_resource_arrival_time"])
+
+(defn- t-key->group-variable-eids
+  "All group-variable eids carrying `t-key`. The directional refactor left a
+  parent and its Heading child sharing one translation key, so `sm/t-key->eid`
+  would only reach one of them."
+  [t-key]
+  (d/q '[:find [?e ...]
+         :in $ ?t-key
+         :where
+         [?e :group-variable/translation-key ?t-key]]
+       (d/db conn)
+       t-key))
+
+;; ===========================================================================================================
+;; Payload
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:missing-docstring]}
+(def payload
+  (->> translation-keys
+       (mapcat t-key->group-variable-eids)
+       (distinct)
+       (mapv (fn [eid] {:db/id eid :group-variable/hide-table-filter? true}))))
+
+;; ===========================================================================================================
+;; Transact Payload
+;; ===========================================================================================================
+
+(comment
+  #_{:clj-kondo/ignore [:missing-docstring]}
+  (def tx-data @(d/transact conn payload)))
+
+;; ===========================================================================================================
+;; In case we need to rollback.
+;; ===========================================================================================================
+
+(comment
+  (sm/rollback-tx! conn @tx-data))

--- a/projects/behave_cms/resources/migrations/2026_08_26_hide_table_shading_filters.clj
+++ b/projects/behave_cms/resources/migrations/2026_08_26_hide_table_shading_filters.clj
@@ -1,7 +1,5 @@
-(ns ^{:migrate/ignore? true} migrations.2026-08-26-hide-table-shading-filters
-  (:require [behave-cms.server :as cms]
-            [behave-cms.store :refer [default-conn]]
-            [datomic.api :as d]
+(ns migrations.2026-08-26-hide-table-shading-filters
+  (:require [datomic.api              :as d]
             [schema-migrate.interface :as sm]))
 
 ;; ===========================================================================================================
@@ -16,21 +14,16 @@
 ;; After this runs, re-export layout.msgpack.
 
 ;; ===========================================================================================================
-;; Initialize
+;; Helpers
 ;; ===========================================================================================================
-
-(cms/init-db!)
-
-#_{:clj-kondo/ignore [:missing-docstring]}
-(def conn (default-conn))
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (def translation-keys
-  ["behaveplus:surface:output:size:surface___fire_size:length-to-width-ratio"
-   "behaveplus:surface:output:wind-and-fuel:wind:midflame-eye-level-wind-speed"
-   "behaveplus:surface:output:wind-and-fuel:fuel:total-live-fuel-load"
-   "behaveplus:surface:output:wind-and-fuel:fuel:total-dead-fuel-load"
-   "behaveplus:surface:output:wind-and-fuel:fuel:total-dead-herbaceous-fuel-load"
+  ["behaveplus:surface:output:size:surface___fire_size:length_to_width_ratio"
+   "behaveplus:surface:output:wind_and_fuel:wind:midflame_eye_level_wind_speed"
+   "behaveplus:surface:output:wind_and_fuel:fuel:total_live_fuel_load"
+   "behaveplus:surface:output:wind_and_fuel:fuel:total_dead_fuel_load"
+   "behaveplus:surface:output:wind_and_fuel:fuel:total_dead_herbaceous_fuel_load"
    "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_length_scorched"
    "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_length_scorched_backing"
    "behaveplus:mortality:output:tree_mortality:tree_mortality:tree_crown_length_scorched_flanking"
@@ -44,36 +37,46 @@
   "All group-variable eids carrying `t-key`. The directional refactor left a
   parent and its Heading child sharing one translation key, so `sm/t-key->eid`
   would only reach one of them."
-  [t-key]
+  [db t-key]
   (d/q '[:find [?e ...]
          :in $ ?t-key
          :where
          [?e :group-variable/translation-key ?t-key]]
-       (d/db conn)
+       db
        t-key))
 
 ;; ===========================================================================================================
 ;; Payload
 ;; ===========================================================================================================
 
+;; Single-step migration: the runner calls (payload-fn db) at startup and
+;; transacts the returned vector.
+
 #_{:clj-kondo/ignore [:missing-docstring]}
-(def payload
+(defn payload-fn [db]
   (->> translation-keys
-       (mapcat t-key->group-variable-eids)
+       (mapcat #(t-key->group-variable-eids db %))
        (distinct)
        (mapv (fn [eid] {:db/id eid :group-variable/hide-table-filter? true}))))
 
 ;; ===========================================================================================================
-;; Transact Payload
+;; Manual REPL usage
+;; ===========================================================================================================
+
+#_{:clj-kondo/ignore [:duplicate-require :missing-docstring :unresolved-namespace]}
+(comment
+  (require '[behave-cms.server        :as cms]
+           '[behave-cms.store         :as store])
+  (cms/init-db!)
+
+  (def conn (store/default-conn))
+
+  (try (def tx-data @(d/transact conn (payload-fn (d/db conn))))
+       (catch Exception e (str "caught exception: " (.getMessage e)))))
+
+;; ===========================================================================================================
+;; Rollback.
 ;; ===========================================================================================================
 
 (comment
-  #_{:clj-kondo/ignore [:missing-docstring]}
-  (def tx-data @(d/transact conn payload)))
-
-;; ===========================================================================================================
-;; In case we need to rollback.
-;; ===========================================================================================================
-
-(comment
-  (sm/rollback-tx! conn @tx-data))
+  (sm/rollback-tx! conn tx-data))

--- a/projects/behave_cms/src/cljs/behave_cms/group_variables/views.cljs
+++ b/projects/behave_cms/src/cljs/behave_cms/group_variables/views.cljs
@@ -92,6 +92,7 @@
    [bool-setting "Hide from Results?" :group-variable/hide-result? group-variable]
    [bool-setting "Hide from CSV Export?" :group-variable/hide-csv? group-variable]
    [bool-setting "Hide from Graphs?" :group-variable/hide-graph? group-variable]
+   [bool-setting "Hide from Table Shading Filters?" :group-variable/hide-table-filter? group-variable]
    [direction-ref-setting group-variable]])
 
 ;;; Public Views


### PR DESCRIPTION
## Purpose
Fire Lab wants certain outputs to have no row on the Table Shading
Filters page and no mark on the Results tables.

1. Added `:group-variable/hide-table-filter?`alongside the existing VMS checkboxes under Group Variable > Settings.
2. Added migration for the outputs listed in the ticket:
  - Length-to-width ratio
  - Midflame wind speed
  - Total fuel loads (all 3)
  - Crown length/volume scorched
  - Fire perimeter/area at first resource arrival time

## Related Issues
Closes BHP1-1637

## Submission Checklist
- [X] Included Jira issue in the PR title (e.g. `BHP1-### <title>`)
- [X] Code passes linter rules (`clj-kondo --lint components/**/src bases/**/src projects/**/src`)
- [X] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

0. Run VMS, app, sync
1. Surface & Crown worksheet. Under Outputs tick `Rate of spread`,
   `Length-to-width ratio`, `Midflame wind speed` and `Total dead fuel
   load`. Give one input a range (e.g. 1-h Fuel Moisture `5, 10, 15`). `Run`.
2. Under Review Run, verify that Table Shading Filters only show `Rate of spread`. The
   other three should be gone.
3. Enable the Rate of spread filter, set a range that excludes some runs, then
   Next.
4. Results: the Rate of spread cells carry checkmark/x's as before. The Length-to-width, Midflame and Total dead fuel load cells carry no mark at all.
   
5. Create Surface & Mortality run. Verify that `Crown length scorched` and `Crown volume scorched` have no filter row and no marks — including their Backing and Flanking columns when Direction Mode is Heading/Backing/Flanking.
7. Create Surface & Contain run. Use the `Add Resources` setting, verify that no rows for Fire perimeter or Fire area at resource arrival time show but that the other Contain outputs filter as normal.
8. Same worksheet switched to `Calculate Minimum Production Rate Only`. Verify that no Contain outputs should be left in the Table Shading Filters list.
9. Verify that CMS > any Group Variable → Settings: `Hide from Table Shading Filters?`
    ticks and persists.